### PR TITLE
Add periodic HTTP status polling alongside MQTT and enforce 1-minute minimum interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ ioBroker adapter for Segway Navimow robotic mowers. Uses the official [Navimow S
 
 - OAuth2 login via Navimow account
 - Real-time status updates via MQTT (WebSocket Secure)
-- HTTP polling as fallback
+- Periodic HTTP status polling alongside MQTT
 - Remote control: Start, Stop, Pause, Resume, Dock
 - Automatic token refresh with MQTT reconnect
+
+MQTT provides real-time event and location updates, while periodic HTTP polling refreshes general status values (for example battery, status and vehicleState) to keep them up to date.
 
 ## Setup
 
@@ -38,6 +40,8 @@ ioBroker adapter for Segway Navimow robotic mowers. Uses the official [Navimow S
 7. The adapter exchanges the code for a token and starts automatically
 
 The token is refreshed automatically. A re-login is only needed if the refresh token expires.
+
+The **Update interval** setting defines the periodic HTTP status polling interval in minutes (minimum: 1 minute). MQTT stays active in parallel for real-time updates.
 
 ## States
 

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -47,15 +47,15 @@
     "interval": {
       "type": "number",
       "newLine": true,
-      "min": 0.5,
+      "min": 1,
       "xs": 12, "sm": 2, "md": 2, "lg": 2, "xl": 2,
       "label": {
-        "en": "Update interval (in minutes)",
-        "de": "Aktualisierungsintervall (in Minuten)"
+        "en": "HTTP polling interval (in minutes)",
+        "de": "HTTP-Polling-Intervall (in Minuten)"
       },
       "help": {
-        "en": "HTTP polling fallback interval. Only used when MQTT is disconnected or stale (no message for 5 min).",
-        "de": "HTTP-Polling-Fallback-Intervall. Wird nur verwendet, wenn MQTT getrennt oder veraltet ist (keine Nachricht seit 5 Min.)."
+        "en": "Periodic HTTP status polling interval. MQTT remains active for real-time updates.",
+        "de": "Periodisches HTTP-Status-Polling-Intervall. MQTT bleibt für Echtzeit-Updates aktiv."
       }
     }
   }

--- a/io-package.json
+++ b/io-package.json
@@ -4,8 +4,8 @@
     "version": "1.0.2",
     "news": {
       "1.0.2": {
-        "en": "Add MQTT location topic with real-time position tracking\nGeneric MQTT topic handling via wildcard subscription",
-        "de": "MQTT Standortthema mit Echtzeit-Positionsverfolgung hinzufügen\nGenerisches MQTT-Themenhandling über Wildcard-Abonnement",
+        "en": "Add MQTT location topic with real-time position tracking\nGeneric MQTT topic handling via wildcard subscription\nAdd periodic HTTP status polling alongside MQTT",
+        "de": "MQTT Standortthema mit Echtzeit-Positionsverfolgung hinzufügen\nGenerisches MQTT-Themenhandling über Wildcard-Abonnement\nPeriodisches HTTP-Status-Polling zusätzlich zu MQTT hinzugefügt",
         "ru": "Добавить тему местоположения MQTT с отслеживанием местоположения в реальном времени\nОбработка темы MQTT через подписку wildcard",
         "pt": "Adicionar tópico de localização MQTT com rastreamento de posição em tempo real\nTratamento genérico de tópicos MQTT através de assinatura wildcard",
         "nl": "MQTT-locatieonderwerp toevoegen met real-time position tracking\nGenerieke MQTT onderwerp behandeling via wildcard abonnement",
@@ -128,7 +128,7 @@
   "protectedNative": [],
   "native": {
     "authCode": "",
-    "interval": 10
+    "interval": 1
   },
   "objects": [],
   "instanceObjects": [

--- a/main.js
+++ b/main.js
@@ -54,13 +54,17 @@ class Navimow extends utils.Adapter {
     this.lastVehicleState = {};
     this.lastMapRender = 0;
     this.mapRenderTimeout = null;
+    this.httpPollRunning = false;
   }
 
   async onReady() {
     this.setState('info.connection', false, true);
-    if (this.config.interval < 0.5) {
-      this.log.info('Set interval to minimum 0.5');
-      this.config.interval = 0.5;
+    const configuredInterval = Number(this.config.interval);
+    if (!Number.isFinite(configuredInterval) || configuredInterval < 1) {
+      this.log.info('Set interval to minimum 1 minute');
+      this.config.interval = 1;
+    } else {
+      this.config.interval = configuredInterval;
     }
 
     this.subscribeStates('*');
@@ -133,20 +137,17 @@ class Navimow extends utils.Adapter {
         this.log.debug('Access token starts with: ' + tokenObj.access_token.substring(0, 20) + '...');
         await this.getDeviceList();
         this.log.debug('Device array: ' + JSON.stringify(this.deviceArray));
-        await this.updateDevices();
+        await this.pollDevices('startup');
 
         // Connect MQTT for real-time updates
         await this.connectMqtt();
 
-        // HTTP polling as fallback only when MQTT is stale (no message for 5 min)
+        // Periodic HTTP polling alongside MQTT real-time updates
         const pollMs = this.config.interval * 60 * 1000;
-        this.updateInterval = setInterval(() => {
-          const mqttStale = Date.now() - this.lastMqttMessage > 5 * 60 * 1000;
-          if (!this.mqttConnected || mqttStale) {
-            this.log.debug('MQTT ' + (this.mqttConnected ? 'stale' : 'disconnected') + ', polling via HTTP');
-            this.updateDevices();
-          }
-        }, pollMs);
+        this.log.info(
+          'Periodic HTTP status polling active every ' + this.config.interval + ' minute(s). MQTT remains active for real-time updates.',
+        );
+        this.updateInterval = setInterval(() => this.pollDevices('interval'), pollMs);
 
         // Schedule token refresh
         if (tokenObj.expires_in) {
@@ -811,6 +812,26 @@ class Navimow extends utils.Adapter {
       });
   }
 
+  async pollDevices(reason) {
+    if (this.httpPollRunning) {
+      this.log.debug('Skipping HTTP status poll (' + reason + '), previous poll still running');
+      return;
+    }
+    this.httpPollRunning = true;
+    try {
+      if (reason === 'interval') {
+        this.log.debug('Running periodic HTTP status poll');
+      } else {
+        this.log.debug('Running HTTP status poll (' + reason + ')');
+      }
+      await this.updateDevices();
+    } catch (error) {
+      this.log.error('HTTP status poll failed (' + reason + '): ' + (error && error.message ? error.message : error));
+    } finally {
+      this.httpPollRunning = false;
+    }
+  }
+
   sendMowerCommand(deviceId, commandName) {
     const mapping = COMMAND_MAP[commandName];
     if (!mapping) {
@@ -856,7 +877,7 @@ class Navimow extends utils.Adapter {
         this.log.info('Command "' + commandName + '" sent successfully');
         clearTimeout(this.refreshTimeout);
         this.refreshTimeout = setTimeout(() => {
-          this.updateDevices();
+          this.pollDevices('post-command');
         }, 5 * 1000);
       })
       .catch((error) => {
@@ -908,7 +929,7 @@ class Navimow extends utils.Adapter {
     this.log.debug('Remote command triggered: ' + command + ' for device ' + deviceId);
 
     if (command === 'Refresh') {
-      this.updateDevices();
+      this.pollDevices('manual refresh');
       return;
     }
 


### PR DESCRIPTION
### Motivation

- Ensure device status values remain up to date even when MQTT messages are delayed or sparse by running periodic HTTP status polls in parallel to MQTT.
- Prevent overlapping HTTP polls and accidental rapid polling by enforcing a sensible minimum interval and guarding concurrent polls.

### Description

- Implement periodic HTTP polling that runs alongside MQTT by adding `pollDevices(reason)` and scheduling it via `setInterval` in `main.js`, replacing direct `updateDevices()` calls for scheduled/manual refreshes.
- Add a concurrency guard with `this.httpPollRunning` to skip overlapping polls and log the reason for skipped runs in `main.js`.
- Validate and normalize the configured interval in `onReady()` to require a numeric minimum of `1` minute and change the default `native.interval` to `1` in `io-package.json` and `admin/jsonConfig.json` UI labels/help text to reflect HTTP polling semantics.
- Update documentation in `README.md` and the `io-package.json` `news` to document the new periodic HTTP polling behavior and clarify that MQTT remains active for real-time updates.