### PR TITLE
Add MQTT location stream watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ ioBroker adapter for Segway Navimow robotic mowers. Uses the official [Navimow S
 - OAuth2 login via Navimow account
 - Real-time status updates via MQTT (WebSocket Secure)
 - Periodic HTTP status polling alongside MQTT
+- MQTT location watchdog with controlled reconnect during active mowing
 - Remote control: Start, Stop, Pause, Resume, Dock
 - Automatic token refresh with MQTT reconnect
 
-MQTT provides real-time event and location updates, while periodic HTTP polling refreshes general status values (for example battery, status and vehicleState) to keep them up to date.
+Periodic HTTP polling refreshes general status values (for example battery, status and vehicleState) to keep them up to date. Location data and mowing progress (`location.mowingPercentage`) are provided by MQTT. During active mowing, the adapter watches the MQTT location stream and performs a controlled MQTT reconnect if location updates stop arriving while HTTP still reports an active mower state.
 
 ## Setup
 
@@ -55,7 +56,8 @@ For each mower device the following channels are created:
 | `{deviceId}.events`      | MQTT events                                              |
 | `{deviceId}.attributes`  | MQTT device attributes                                   |
 | `{deviceId}.remote`      | Remote control buttons                                   |
-| `{deviceId}.location`    | Real-time mower position (via MQTT)                      |
+| `{deviceId}.location`    | Real-time mower position and mowing progress (via MQTT)  |
+| `{deviceId}.diagnostics` | MQTT location watchdog diagnostics                       |
 
 ### vehicleState
 
@@ -100,7 +102,7 @@ Remote states reflect the current device state with `ack:true`. For example, whe
 
 ### Location
 
-The `location` channel receives real-time position data via MQTT while the mower is active. Coordinates are relative to the mowing area (in meters), not GPS.
+The `location` channel receives real-time position data and mowing progress (`mowingPercentage`) via MQTT while the mower is active. Coordinates are relative to the mowing area (in meters), not GPS. These values are not derived from periodic HTTP status polling.
 
 | State                  | Description            |
 | ---------------------- | ---------------------- |
@@ -111,6 +113,19 @@ The `location` channel receives real-time position data via MQTT while the mower
 | `location.time`        | Timestamp              |
 
 The position data can be visualized as a mowing map using Grafana (e.g. with the Plotly or Geomap panel) or ioBroker.vis.
+
+### Diagnostics
+
+The `diagnostics` channel contains read-only values for the MQTT location watchdog.
+
+| State                                | Description                                      |
+| ------------------------------------ | ------------------------------------------------ |
+| `diagnostics.lastLocationMessage`    | Timestamp of the last received MQTT location message |
+| `diagnostics.locationMqttStale`      | `true` if the location stream is stale while the mower is active |
+| `diagnostics.lastMqttRecovery`       | Timestamp of the last controlled MQTT recovery   |
+| `diagnostics.lastLocationAgeSeconds` | Age of the last MQTT location message in seconds |
+
+If HTTP polling reports an active mowing state but no MQTT `location` message is received for at least three minutes, the adapter marks the location stream as stale and reconnects MQTT. Recoveries are rate-limited to at most once every five minutes per device. Battery, status and `vehicleState` continue to be updated by periodic HTTP polling independently from this watchdog.
 
 ### Mowing Map
 

--- a/main.js
+++ b/main.js
@@ -17,6 +17,11 @@ const CLIENT_SECRET = '57056e15-722e-42be-bbaa-b0cbfb208a52';
 const REDIRECT_URI = 'http://localhost:1/callback';
 
 
+// Location MQTT watchdog
+const LOCATION_STALE_MS = 3 * 60 * 1000;
+const LOCATION_RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
+const ACTIVE_LOCATION_STATES = new Set(['isRunning', 'mowing', 'isMowing', 'isMapping', 'mapping']);
+
 // Command mapping: name -> { command, params }
 const COMMAND_MAP = {
   start: { command: 'action.devices.commands.StartStop', params: { on: true } },
@@ -50,6 +55,11 @@ class Navimow extends utils.Adapter {
     this.mqttRefreshing = false;
     this.mqttErrorCount = 0;
     this.lastMqttMessage = 0;
+    this.lastLocationMessage = {};
+    this.lastLocationRecovery = {};
+    this.locationRecoveryRunning = false;
+    this.runningSince = {};
+    this.locationMqttStale = {};
     this.locationHistory = {};
     this.lastVehicleState = {};
     this.lastMapRender = 0;
@@ -250,6 +260,7 @@ class Navimow extends utils.Adapter {
         this.log.debug('MQTT clientId: ' + mqttOpts.clientId);
         this.log.debug('MQTT username: ' + (mqttUsername || 'none'));
         this.mqttClient = mqtt.connect(brokerUrl, mqttOpts);
+        const mqttClient = this.mqttClient;
 
         this.mqttClient.on('connect', () => {
           if (this.mqttErrorCount > 0) {
@@ -310,8 +321,10 @@ class Navimow extends utils.Adapter {
             this.log.info('MQTT connection closed');
           }
           this.mqttConnected = false;
-          // Refresh MQTT credentials on disconnect (userName/pwdInfo are bound to OAuth token)
-          if (!this.mqttRefreshing) {
+          // Refresh MQTT credentials on unplanned disconnect (userName/pwdInfo are bound to OAuth token)
+          if (/** @type {any} */ (mqttClient).suppressCredentialRefresh) {
+            this.log.debug('MQTT credential refresh skipped for controlled disconnect');
+          } else if (!this.mqttRefreshing) {
             this.refreshMqttCredentials();
           }
         });
@@ -344,6 +357,18 @@ class Navimow extends utils.Adapter {
       if (!this.deviceArray.includes(deviceId)) {
         this.log.debug('MQTT message for unknown device: ' + deviceId);
         return;
+      }
+
+      if (channel === 'location') {
+        const now = Date.now();
+        this.lastLocationMessage[deviceId] = now;
+        this.setState(deviceId + '.diagnostics.lastLocationMessage', now, true);
+        this.setState(deviceId + '.diagnostics.lastLocationAgeSeconds', 0, true);
+        if (this.locationMqttStale[deviceId]) {
+          this.locationMqttStale[deviceId] = false;
+          this.setState(deviceId + '.diagnostics.locationMqttStale', false, true);
+          this.log.info('MQTT location stream recovered: device=' + deviceId);
+        }
       }
 
       let data = JSON.parse(payload.toString());
@@ -523,12 +548,106 @@ class Navimow extends utils.Adapter {
     this.setState(deviceId + '.map', base64, true);
   }
 
-  disconnectMqtt() {
-    if (this.mqttClient) {
-      this.mqttClient.end(true);
-      this.mqttClient = null;
-      this.mqttConnected = false;
-      this.log.info('MQTT disconnected');
+  disconnectMqtt(suppressCredentialRefresh = false) {
+    if (!this.mqttClient) {
+      return Promise.resolve();
+    }
+
+    const client = this.mqttClient;
+    this.mqttClient = null;
+    this.mqttConnected = false;
+    if (suppressCredentialRefresh) {
+      /** @type {any} */ (client).suppressCredentialRefresh = true;
+    }
+
+    return /** @type {Promise<void>} */ (new Promise((resolve) => {
+      let resolved = false;
+      const finish = () => {
+        if (resolved) return;
+        resolved = true;
+        this.log.info('MQTT disconnected');
+        resolve();
+      };
+      client.once('close', finish);
+      client.end(true, finish);
+      setTimeout(finish, 2000);
+    }));
+  }
+
+  isLocationActiveState(vehicleState) {
+    return ACTIVE_LOCATION_STATES.has(String(vehicleState));
+  }
+
+  checkLocationWatchdog(deviceId, vehicleState) {
+    const now = Date.now();
+    const active = this.isLocationActiveState(vehicleState);
+
+    if (!active) {
+      this.runningSince[deviceId] = 0;
+      if (this.locationMqttStale[deviceId]) {
+        this.locationMqttStale[deviceId] = false;
+        this.setState(deviceId + '.diagnostics.locationMqttStale', false, true);
+      } else {
+        this.setState(deviceId + '.diagnostics.locationMqttStale', false, true);
+      }
+      this.setState(deviceId + '.diagnostics.lastLocationAgeSeconds', 0, true);
+      return;
+    }
+
+    if (!this.runningSince[deviceId]) {
+      this.runningSince[deviceId] = now;
+    }
+
+    const activeAge = now - this.runningSince[deviceId];
+    const lastLocation = this.lastLocationMessage[deviceId] || 0;
+    const locationAge = lastLocation ? now - lastLocation : activeAge;
+    const ageSeconds = Math.round(locationAge / 1000);
+    this.setState(deviceId + '.diagnostics.lastLocationAgeSeconds', ageSeconds, true);
+
+    if (activeAge < LOCATION_STALE_MS || locationAge < LOCATION_STALE_MS) {
+      if (this.locationMqttStale[deviceId]) {
+        this.locationMqttStale[deviceId] = false;
+        this.setState(deviceId + '.diagnostics.locationMqttStale', false, true);
+      }
+      return;
+    }
+
+    this.locationMqttStale[deviceId] = true;
+    this.setState(deviceId + '.diagnostics.locationMqttStale', true, true);
+
+    const lastRecovery = this.lastLocationRecovery[deviceId] || 0;
+    if (now - lastRecovery < LOCATION_RECOVERY_COOLDOWN_MS) {
+      this.log.debug(
+        'MQTT location stream stale: device=' + deviceId + ' vehicleState=' + vehicleState + ' age=' + ageSeconds + 's action=cooldown',
+      );
+      return;
+    }
+
+    this.log.warn(
+      'MQTT location stream stale: device=' + deviceId + ' vehicleState=' + vehicleState + ' age=' + ageSeconds + 's action=reconnect',
+    );
+    this.recoverMqttLocationStream(deviceId);
+  }
+
+  async recoverMqttLocationStream(deviceId) {
+    if (this.locationRecoveryRunning) {
+      this.log.debug('MQTT location recovery already running, skipping device=' + deviceId);
+      return;
+    }
+
+    this.locationRecoveryRunning = true;
+    const now = Date.now();
+    this.lastLocationRecovery[deviceId] = now;
+    this.setState(deviceId + '.diagnostics.lastMqttRecovery', now, true);
+
+    try {
+      await this.disconnectMqtt(true);
+      await this.connectMqtt();
+      this.log.info('MQTT location stream reconnect completed: device=' + deviceId);
+    } catch (e) {
+      this.log.warn('MQTT location recovery failed: device=' + deviceId + ' error=' + e.message);
+    } finally {
+      this.locationRecoveryRunning = false;
     }
   }
 
@@ -560,8 +679,9 @@ class Navimow extends utils.Adapter {
             this.mqttClient.options.username = newUsername;
             this.mqttClient.options.password = newPassword;
           }
-          if (this.mqttClient.options.wsOptions && this.mqttClient.options.wsOptions.headers) {
-            this.mqttClient.options.wsOptions.headers.Authorization = 'Bearer ' + this.session.access_token;
+          const wsOptions = /** @type {any} */ (this.mqttClient.options.wsOptions);
+          if (wsOptions && wsOptions.headers) {
+            wsOptions.headers.Authorization = 'Bearer ' + this.session.access_token;
           }
           this.log.debug('MQTT credentials updated for next reconnect');
         }
@@ -727,6 +847,31 @@ class Navimow extends utils.Adapter {
             common: { name: 'Mowing Map (PNG base64)', write: false, read: true, type: 'string', role: 'text' },
             native: {},
           });
+          await this.setObjectNotExistsAsync(id + '.diagnostics', {
+            type: 'channel',
+            common: { name: 'Diagnostics' },
+            native: {},
+          });
+          await this.setObjectNotExistsAsync(id + '.diagnostics.lastLocationMessage', {
+            type: 'state',
+            common: { name: 'Last MQTT location message', write: false, read: true, type: 'number', role: 'date' },
+            native: {},
+          });
+          await this.setObjectNotExistsAsync(id + '.diagnostics.locationMqttStale', {
+            type: 'state',
+            common: { name: 'MQTT location stream stale', write: false, read: true, type: 'boolean', role: 'indicator' },
+            native: {},
+          });
+          await this.setObjectNotExistsAsync(id + '.diagnostics.lastMqttRecovery', {
+            type: 'state',
+            common: { name: 'Last MQTT recovery', write: false, read: true, type: 'number', role: 'date' },
+            native: {},
+          });
+          await this.setObjectNotExistsAsync(id + '.diagnostics.lastLocationAgeSeconds', {
+            type: 'state',
+            common: { name: 'Last MQTT location age', write: false, read: true, type: 'number', role: 'value', unit: 's' },
+            native: {},
+          });
 
           const remoteArray = [
             { command: 'Refresh', name: 'Refresh status' },
@@ -802,6 +947,9 @@ class Navimow extends utils.Adapter {
             states,
           });
 
+          if (deviceData.vehicleState != null) {
+            this.checkLocationWatchdog(id, deviceData.vehicleState);
+          }
         }
       })
       .catch((error) => {

--- a/main.js
+++ b/main.js
@@ -259,10 +259,13 @@ class Navimow extends utils.Adapter {
         this.log.info('MQTT connecting to ' + brokerUrl);
         this.log.debug('MQTT clientId: ' + mqttOpts.clientId);
         this.log.debug('MQTT username: ' + (mqttUsername || 'none'));
-        this.mqttClient = mqtt.connect(brokerUrl, mqttOpts);
-        const mqttClient = this.mqttClient;
+        const mqttClient = mqtt.connect(brokerUrl, mqttOpts);
+        this.mqttClient = mqttClient;
 
-        this.mqttClient.on('connect', () => {
+        mqttClient.on('connect', () => {
+          if (this.mqttClient !== mqttClient) {
+            return;
+          }
           if (this.mqttErrorCount > 0) {
             this.log.info('MQTT reconnected successfully after ' + this.mqttErrorCount + ' error(s)');
           } else {
@@ -271,9 +274,7 @@ class Navimow extends utils.Adapter {
           this.mqttConnected = true;
           this.mqttErrorCount = 0;
           // Reset reconnect interval on successful connect
-          if (this.mqttClient) {
-            this.mqttClient.options.reconnectPeriod = 10000;
-          }
+          mqttClient.options.reconnectPeriod = 10000;
           // Subscribe to device topics
           for (const deviceId of this.deviceArray) {
             const topics = [
@@ -284,7 +285,10 @@ class Navimow extends utils.Adapter {
               '/downlink/vehicle/' + deviceId + '/#',
             ];
             for (const topic of topics) {
-              this.mqttClient && this.mqttClient.subscribe(topic, (err) => {
+              mqttClient.subscribe(topic, (err) => {
+                if (this.mqttClient !== mqttClient) {
+                  return;
+                }
                 if (err) {
                   this.log.error('MQTT subscribe error for ' + topic + ': ' + err.message);
                 } else {
@@ -295,41 +299,55 @@ class Navimow extends utils.Adapter {
           }
         });
 
-        this.mqttClient.on('message', (topic, payload) => {
+        mqttClient.on('message', (topic, payload) => {
+          if (this.mqttClient !== mqttClient) {
+            return;
+          }
           this.lastMqttMessage = Date.now();
           this.handleMqttMessage(topic, payload);
         });
 
-        this.mqttClient.on('error', (err) => {
+        mqttClient.on('error', (err) => {
+          if (this.mqttClient !== mqttClient) {
+            return;
+          }
           this.mqttErrorCount++;
           if (this.mqttErrorCount === 1) {
             this.log.error('MQTT error: ' + err.message);
           } else {
             this.log.debug('MQTT error: ' + err.message);
           }
-          if (this.mqttErrorCount === 3 && this.mqttClient) {
+          if (this.mqttErrorCount === 3) {
             this.log.info('MQTT repeated errors, increasing reconnect interval to 10 min. HTTP polling is active as fallback.');
-            this.mqttClient.options.reconnectPeriod = 600000;
+            mqttClient.options.reconnectPeriod = 600000;
           }
           if ('code' in err) {
             this.log.debug('MQTT error code: ' + /** @type {any} */ (err).code);
           }
         });
 
-        this.mqttClient.on('close', () => {
+        mqttClient.on('close', () => {
+          // Refresh MQTT credentials on unplanned disconnect (userName/pwdInfo are bound to OAuth token)
+          if (/** @type {any} */ (mqttClient).suppressCredentialRefresh) {
+            this.log.debug('MQTT credential refresh skipped for controlled disconnect');
+            return;
+          }
+          if (this.mqttClient !== mqttClient) {
+            return;
+          }
           if (this.mqttConnected) {
             this.log.info('MQTT connection closed');
           }
           this.mqttConnected = false;
-          // Refresh MQTT credentials on unplanned disconnect (userName/pwdInfo are bound to OAuth token)
-          if (/** @type {any} */ (mqttClient).suppressCredentialRefresh) {
-            this.log.debug('MQTT credential refresh skipped for controlled disconnect');
-          } else if (!this.mqttRefreshing) {
+          if (!this.mqttRefreshing) {
             this.refreshMqttCredentials();
           }
         });
 
-        this.mqttClient.on('reconnect', () => {
+        mqttClient.on('reconnect', () => {
+          if (this.mqttClient !== mqttClient) {
+            return;
+          }
           if (this.mqttErrorCount >= 3) {
             this.log.info('MQTT reconnecting...');
           } else {
@@ -590,7 +608,9 @@ class Navimow extends utils.Adapter {
       } else {
         this.setState(deviceId + '.diagnostics.locationMqttStale', false, true);
       }
-      this.setState(deviceId + '.diagnostics.lastLocationAgeSeconds', 0, true);
+      const lastLocation = this.lastLocationMessage[deviceId] || 0;
+      const ageSeconds = lastLocation ? Math.round((now - lastLocation) / 1000) : 0;
+      this.setState(deviceId + '.diagnostics.lastLocationAgeSeconds', ageSeconds, true);
       return;
     }
 
@@ -643,7 +663,7 @@ class Navimow extends utils.Adapter {
     try {
       await this.disconnectMqtt(true);
       await this.connectMqtt();
-      this.log.info('MQTT location stream reconnect completed: device=' + deviceId);
+      this.log.info('MQTT location stream reconnect initiated: device=' + deviceId);
     } catch (e) {
       this.log.warn('MQTT location recovery failed: device=' + deviceId + ' error=' + e.message);
     } finally {


### PR DESCRIPTION
### Motivation
- Address cases where `location.mowingPercentage` (MQTT) stalls while HTTP still reports `vehicleState=isRunning`, by tracking per-device MQTT location receipts and performing controlled reconnects only when appropriate.

### Description
- Add location watchdog constants `LOCATION_STALE_MS`, `LOCATION_RECOVERY_COOLDOWN_MS` and `ACTIVE_LOCATION_STATES` and new constructor fields `lastLocationMessage`, `lastLocationRecovery`, `locationRecoveryRunning`, and `runningSince` to track per-device state.
- Update `handleMqttMessage` so every `location` message updates `this.lastLocationMessage[deviceId]` and clears stale diagnostics immediately, without triggering recovery when `mowingPercentage` or position are unchanged.
- Create per-device diagnostics channel `{deviceId}.diagnostics` with read-only states `lastLocationMessage`, `locationMqttStale`, `lastMqttRecovery` and `lastLocationAgeSeconds` during device setup.
- Implement `checkLocationWatchdog(deviceId, vehicleState)` and `recoverMqttLocationStream(deviceId)` and wire watchdog invocation into `updateDevices()` after successful HTTP `getVehicleStatus` processing when `vehicleState` indicates active mowing; enforce a 3-minute grace period and a 5-minute per-device recovery cooldown.
- Add controlled `disconnectMqtt(suppressCredentialRefresh = false)` that suppresses the automatic credential refresh on intentional disconnects to avoid duplicate reconnects, and adapt `connectMqtt()` close handler to skip credential refresh for controlled disconnects.
- Minor README updates documenting that battery/status/`vehicleState` are stabilized via HTTP polling, while `location`/`mowingPercentage` come via MQTT and are monitored by the new watchdog.

All automated checks completed successfully.
