### PR TITLE
security: redact sensitive data from logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@
 
 ioBroker adapter for Segway Navimow robotic mowers. Uses the official [Navimow SDK](https://github.com/segwaynavimow/navimow-sdk) REST API and MQTT for real-time updates.
 
+## About this fork
+
+This is a fork of [TA2k/ioBroker.navimow](https://github.com/TA2k/ioBroker.navimow) with the following changes not (yet) present upstream:
+
+- **Security fix:** OAuth tokens, passwords and other credentials are now redacted before being written to the debug/error log (previously full token responses and MQTT credentials were logged in plain text).
+- **Configurable client credentials:** the Navimow `CLIENT_ID`/`CLIENT_SECRET` can be overridden via the `NAVIMOW_CLIENT_ID`/`NAVIMOW_CLIENT_SECRET` environment variables, falling back to the existing public Home Assistant integration values.
+
 ## Features
 
 - OAuth2 login via Navimow account

--- a/main.js
+++ b/main.js
@@ -12,9 +12,48 @@ const states = require('./lib/states.json');
 
 const API_BASE_URL = 'https://navimow-fra.ninebot.com';
 const OAUTH2_TOKEN_URL = API_BASE_URL + '/openapi/oauth/getAccessToken';
-const CLIENT_ID = 'homeassistant';
-const CLIENT_SECRET = '57056e15-722e-42be-bbaa-b0cbfb208a52';
+// CLIENT_ID/CLIENT_SECRET are the public OAuth client credentials of the Home Assistant
+// integration for this cloud API (not a user secret). Overridable via env for flexibility.
+const CLIENT_ID = process.env.NAVIMOW_CLIENT_ID || 'homeassistant';
+const CLIENT_SECRET = process.env.NAVIMOW_CLIENT_SECRET || '57056e15-722e-42be-bbaa-b0cbfb208a52';
 const REDIRECT_URI = 'http://localhost:1/callback';
+
+// Keys that must never appear in plain text in logs
+const SENSITIVE_KEYS = new Set([
+  'access_token',
+  'refresh_token',
+  'token',
+  'pwdInfo',
+  'password',
+  'mqttPassword',
+  'userName',
+  'secret',
+  'client_secret',
+  'code',
+  'authCode',
+]);
+
+function redact(value) {
+  if (Array.isArray(value)) {
+    return value.map(redact);
+  }
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = SENSITIVE_KEYS.has(key) ? '***redacted***' : redact(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+function safeStringify(value) {
+  try {
+    return JSON.stringify(redact(value));
+  } catch {
+    return '[unstringifiable]';
+  }
+}
 
 
 // Location MQTT watchdog
@@ -197,9 +236,9 @@ class Navimow extends utils.Adapter {
       headers: this.getAuthHeaders(),
     })
       .then((res) => {
-        this.log.debug('MQTT info: ' + JSON.stringify(res.data));
+        this.log.debug('MQTT info: ' + safeStringify(res.data));
         if (!res.data || res.data.code !== 1) {
-          this.log.warn('Failed to get MQTT info: ' + JSON.stringify(res.data));
+          this.log.warn('Failed to get MQTT info: ' + safeStringify(res.data));
           return;
         }
         const mqttInfo = res.data.data ?? {};
@@ -215,7 +254,7 @@ class Navimow extends utils.Adapter {
         const mqttUsername = mqttInfo.userName;
         const mqttPassword = mqttInfo.pwdInfo;
 
-        this.log.debug('MQTT info raw: ' + JSON.stringify(mqttInfo));
+        this.log.debug('MQTT info raw: ' + safeStringify(mqttInfo));
 
         let brokerUrl;
         const mqttOpts = {
@@ -357,7 +396,7 @@ class Navimow extends utils.Adapter {
       })
       .catch((error) => {
         this.log.warn('MQTT setup failed: ' + error.message);
-        error.response && this.log.debug(JSON.stringify(error.response.data));
+        error.response && this.log.debug(safeStringify(error.response.data));
       });
   }
 
@@ -744,16 +783,16 @@ class Navimow extends utils.Adapter {
       },
     })
       .then((res) => {
-        this.log.debug(JSON.stringify(res.data));
+        this.log.debug(safeStringify(res.data));
         if (res.data && res.data.access_token) {
           return res.data;
         }
-        this.log.error('Token exchange failed: ' + JSON.stringify(res.data));
+        this.log.error('Token exchange failed: ' + safeStringify(res.data));
         return null;
       })
       .catch((error) => {
         this.log.error('Token exchange error: ' + error.message);
-        error.response && this.log.error(JSON.stringify(error.response.data));
+        error.response && this.log.error(safeStringify(error.response.data));
         return null;
       });
   }
@@ -772,16 +811,16 @@ class Navimow extends utils.Adapter {
       },
     })
       .then((res) => {
-        this.log.debug(JSON.stringify(res.data));
+        this.log.debug(safeStringify(res.data));
         if (res.data && res.data.access_token) {
           return res.data;
         }
-        this.log.warn('Token refresh returned no token: ' + JSON.stringify(res.data));
+        this.log.warn('Token refresh returned no token: ' + safeStringify(res.data));
         return null;
       })
       .catch((error) => {
         this.log.warn('Token refresh failed: ' + error.message);
-        error.response && this.log.debug(JSON.stringify(error.response.data));
+        error.response && this.log.debug(safeStringify(error.response.data));
         return null;
       });
   }
@@ -822,9 +861,9 @@ class Navimow extends utils.Adapter {
       headers: this.getAuthHeaders(),
     })
       .then(async (res) => {
-        this.log.debug(JSON.stringify(res.data));
+        this.log.debug(safeStringify(res.data));
         if (res.data && res.data.code !== 1) {
-          this.log.error('getDeviceList failed: ' + (res.data.desc || JSON.stringify(res.data)));
+          this.log.error('getDeviceList failed: ' + (res.data.desc || safeStringify(res.data)));
           return;
         }
         const devices = res.data.data?.payload?.devices || [];
@@ -921,7 +960,7 @@ class Navimow extends utils.Adapter {
       })
       .catch((error) => {
         this.log.error('getDeviceList error: ' + error.message);
-        error.response && this.log.error(JSON.stringify(error.response.data));
+        error.response && this.log.error(safeStringify(error.response.data));
       });
   }
 
@@ -943,10 +982,10 @@ class Navimow extends utils.Adapter {
       },
     })
       .then((res) => {
-        this.log.debug(JSON.stringify(res.data));
+        this.log.debug(safeStringify(res.data));
         if (!res.data || res.data.code !== 1) {
           this.log.error(
-            'updateDevices failed: ' + ((res.data && res.data.desc) || JSON.stringify(res.data)),
+            'updateDevices failed: ' + ((res.data && res.data.desc) || safeStringify(res.data)),
           );
           return;
         }
@@ -980,7 +1019,7 @@ class Navimow extends utils.Adapter {
           return;
         }
         this.log.error('updateDevices error: ' + error.message);
-        error.response && this.log.error(JSON.stringify(error.response.data));
+        error.response && this.log.error(safeStringify(error.response.data));
       });
   }
 
@@ -1033,10 +1072,10 @@ class Navimow extends utils.Adapter {
       },
     })
       .then((res) => {
-        this.log.debug(JSON.stringify(res.data));
+        this.log.debug(safeStringify(res.data));
         if (!res.data || res.data.code !== 1) {
           this.log.error(
-            'Command failed: ' + ((res.data && res.data.desc) || JSON.stringify(res.data)),
+            'Command failed: ' + ((res.data && res.data.desc) || safeStringify(res.data)),
           );
           return;
         }
@@ -1060,7 +1099,7 @@ class Navimow extends utils.Adapter {
           return;
         }
         this.log.error('sendCommand error: ' + error.message);
-        error.response && this.log.error(JSON.stringify(error.response.data));
+        error.response && this.log.error(safeStringify(error.response.data));
       });
   }
 


### PR DESCRIPTION
## Summary
- Adds `redact()` / `safeStringify()` helpers that mask sensitive fields (`access_token`, `refresh_token`, `pwdInfo`, `password`, `userName`, `client_secret`, `code`, ...) before any debug/error log output. Previously full OAuth token responses and MQTT credentials were dumped to the ioBroker log via `JSON.stringify(res.data)` in ~15 places — a problem if users share debug logs (e.g. in GitHub issues).
- Allows `CLIENT_ID` / `CLIENT_SECRET` to be overridden via `NAVIMOW_CLIENT_ID` / `NAVIMOW_CLIENT_SECRET` env vars, falling back to the existing values, for users who want to use their own registered client.

## Test plan
- [x] `npx eslint .` passes with no findings
- [x] `npm run test:js` passes (1/1)
- [x] `node -c main.js` syntax check passes
- [ ] Manual run against a real device (no hardware available for this PR)
