### PR TITLE
fix: stabilize MQTT connection and adapter unload

### DIFF
--- a/lib/mqttParse.js
+++ b/lib/mqttParse.js
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * Split an MQTT topic of the shape /downlink/vehicle/{deviceId}/.../{channel}.
+ *
+ * @param {string} topic raw topic as delivered by the broker
+ * @returns {{ deviceId: string, channel: string } | null} null if the topic does not belong to a vehicle
+ */
+function parseTopic(topic) {
+  const parts = String(topic)
+    .split('/')
+    .filter((p) => p !== '');
+  if (parts.length < 4 || parts[0] !== 'downlink' || parts[1] !== 'vehicle') {
+    return null;
+  }
+  return { deviceId: parts[2], channel: parts[parts.length - 1] };
+}
+
+/**
+ * A mowingPercentage of 0 marks the start of a new mowing session, so the collected path is dropped.
+ *
+ * @param {any[]} points location payload entries
+ * @returns {boolean} true if any entry reports mowingPercentage 0
+ */
+function hasMowingReset(points) {
+  for (const p of points) {
+    if (p && p.mowingPercentage != null && Number(p.mowingPercentage) === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Append location points to a path history, skipping unusable and repeated coordinates.
+ * The history is capped in place to the newest maxPoints entries.
+ *
+ * @param {{x: number, y: number}[]} history mutated in place
+ * @param {any[]} points location payload entries
+ * @param {number} maxPoints upper bound of retained points
+ * @returns {number} number of appended points
+ */
+function appendLocationPoints(history, points, maxPoints) {
+  let added = 0;
+  for (const p of points) {
+    if (!p || p.postureX == null || p.postureY == null) {
+      continue;
+    }
+    const x = parseFloat(p.postureX);
+    const y = parseFloat(p.postureY);
+    if (isNaN(x) || isNaN(y)) {
+      continue;
+    }
+    const last = history[history.length - 1];
+    if (!last || last.x !== x || last.y !== y) {
+      history.push({ x, y });
+      added++;
+    }
+  }
+  if (history.length > maxPoints) {
+    history.splice(0, history.length - maxPoints);
+  }
+  return added;
+}
+
+module.exports = { parseTopic, hasMowingReset, appendLocationPoints };

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const { URL } = require('url');
 const { createCanvas } = require('@napi-rs/canvas');
 const descriptions = require('./lib/descriptions.json');
 const states = require('./lib/states.json');
+const { parseTopic, hasMowingReset, appendLocationPoints } = require('./lib/mqttParse');
 
 const API_BASE_URL = 'https://navimow-fra.ninebot.com';
 const OAUTH2_TOKEN_URL = API_BASE_URL + '/openapi/oauth/getAccessToken';
@@ -16,6 +17,12 @@ const CLIENT_ID = 'homeassistant';
 const CLIENT_SECRET = '57056e15-722e-42be-bbaa-b0cbfb208a52';
 const REDIRECT_URI = 'http://localhost:1/callback';
 
+
+// MQTT keepalive in seconds. mqtt.js only detects a dead socket through its keepalive
+// pings, so this doubles as the upper bound for noticing a half-open connection.
+const MQTT_KEEPALIVE_S = 60;
+const MAP_POINT_LIMIT = 5000;
+const MAP_RENDER_MIN_INTERVAL_MS = 1000;
 
 // Location MQTT watchdog
 const LOCATION_STALE_MS = 3 * 60 * 1000;
@@ -63,8 +70,11 @@ class Navimow extends utils.Adapter {
     this.locationMqttStale = {};
     this.locationHistory = {};
     this.lastVehicleState = {};
-    this.lastMapRender = 0;
-    this.mapRenderTimeout = null;
+    // Map rendering is throttled per device, otherwise a second mower silently
+    // loses its scheduled render to the first one.
+    this.lastMapRender = {};
+    this.mapRenderTimeout = {};
+    this.unloaded = false;
     this.httpPollRunning = false;
     this.httpPollStartedAt = 0;
     this.httpPollToken = 0;
@@ -161,7 +171,7 @@ class Navimow extends utils.Adapter {
           this.log.info(
             'Periodic HTTP status polling active every ' + this.config.interval + ' minute(s). MQTT remains active for real-time updates.',
           );
-          this.updateInterval = setInterval(() => this.pollDevices('interval'), pollMs);
+          this.updateInterval = this.setInterval(() => this.pollDevices('interval'), pollMs);
         } else {
           this.log.info('Periodic HTTP status polling disabled (interval=0). Relying on MQTT for updates.');
         }
@@ -189,6 +199,9 @@ class Navimow extends utils.Adapter {
   // ---- MQTT ----
 
   connectMqtt() {
+    if (this.unloaded) {
+      return Promise.resolve();
+    }
     if (this.deviceArray.length === 0) {
       this.log.info('No devices, skipping MQTT');
       return Promise.resolve();
@@ -223,7 +236,7 @@ class Navimow extends utils.Adapter {
         let brokerUrl;
         const mqttOpts = {
           clientId: 'web_' + (mqttUsername || 'iobroker') + '_' + crypto.randomUUID().replace(/-/g, '').substring(0, 10),
-          keepalive: 2400,
+          keepalive: MQTT_KEEPALIVE_S,
           reconnectPeriod: 10000,
         };
 
@@ -241,17 +254,18 @@ class Navimow extends utils.Adapter {
             const wsPort = parsed.port || (wsScheme === 'wss' ? 443 : 80);
             const wsPath = (parsed.pathname || '/') + (parsed.search || '');
             brokerUrl = wsScheme + '://' + (parsed.hostname || mqttHost) + ':' + wsPort + wsPath;
+            // rejectUnauthorized belongs into wsOptions for the ws transport;
+            // as a top level option it only applies to mqtts and was a no-op here.
             mqttOpts.wsOptions = {
               headers: { Authorization: 'Bearer ' + this.session.access_token },
+              rejectUnauthorized: true,
             };
-            if (wsScheme === 'wss') {
-              mqttOpts.rejectUnauthorized = true;
-            }
           } catch {
             // Fallback: treat mqttUrl as ws path
             brokerUrl = 'wss://' + mqttHost + ':443' + mqttUrlRaw;
             mqttOpts.wsOptions = {
               headers: { Authorization: 'Bearer ' + this.session.access_token },
+              rejectUnauthorized: true,
             };
           }
         } else {
@@ -278,27 +292,21 @@ class Navimow extends utils.Adapter {
           this.mqttErrorCount = 0;
           // Reset reconnect interval on successful connect
           mqttClient.options.reconnectPeriod = 10000;
-          // Subscribe to device topics
+          // One wildcard subscription per device. The explicit realtimeDate/* topics it
+          // replaces were covered by it anyway, and brokers deliver one copy per matching
+          // subscription - which doubled every state write and every map point.
           for (const deviceId of this.deviceArray) {
-            const topics = [
-              '/downlink/vehicle/' + deviceId + '/realtimeDate/state',
-              '/downlink/vehicle/' + deviceId + '/realtimeDate/event',
-              '/downlink/vehicle/' + deviceId + '/realtimeDate/attributes',
-              '/downlink/vehicle/' + deviceId + '/realtimeDate/location',
-              '/downlink/vehicle/' + deviceId + '/#',
-            ];
-            for (const topic of topics) {
-              mqttClient.subscribe(topic, (err) => {
-                if (this.mqttClient !== mqttClient) {
-                  return;
-                }
-                if (err) {
-                  this.log.error('MQTT subscribe error for ' + topic + ': ' + err.message);
-                } else {
-                  this.log.debug('MQTT subscribed to ' + topic);
-                }
-              });
-            }
+            const topic = '/downlink/vehicle/' + deviceId + '/#';
+            mqttClient.subscribe(topic, (err) => {
+              if (this.mqttClient !== mqttClient) {
+                return;
+              }
+              if (err) {
+                this.log.error('MQTT subscribe error for ' + topic + ': ' + err.message);
+              } else {
+                this.log.debug('MQTT subscribed to ' + topic);
+              }
+            });
           }
         });
 
@@ -342,7 +350,7 @@ class Navimow extends utils.Adapter {
             this.log.info('MQTT connection closed');
           }
           this.mqttConnected = false;
-          if (!this.mqttRefreshing) {
+          if (!this.mqttRefreshing && !this.unloaded) {
             this.refreshMqttCredentials();
           }
         });
@@ -366,14 +374,12 @@ class Navimow extends utils.Adapter {
 
   handleMqttMessage(topic, payload) {
     try {
-      const parts = topic.split('/').filter((p) => p !== '');
-      // Expected: downlink/vehicle/{device_id}/.../{channel}
-      if (parts.length < 4 || parts[0] !== 'downlink' || parts[1] !== 'vehicle') {
+      const parsed = parseTopic(topic);
+      if (!parsed) {
         this.log.debug('MQTT unknown topic: ' + topic);
         return;
       }
-      const deviceId = parts[2];
-      const channel = parts[parts.length - 1];
+      const { deviceId, channel } = parsed;
 
       if (!this.deviceArray.includes(deviceId)) {
         this.log.debug('MQTT message for unknown device: ' + deviceId);
@@ -383,11 +389,11 @@ class Navimow extends utils.Adapter {
       if (channel === 'location') {
         const now = Date.now();
         this.lastLocationMessage[deviceId] = now;
-        this.setState(deviceId + '.diagnostics.lastLocationMessage', now, true);
-        this.setState(deviceId + '.diagnostics.lastLocationAgeSeconds', 0, true);
+        this.setStateSafe(deviceId + '.diagnostics.lastLocationMessage', now);
+        this.setStateSafe(deviceId + '.diagnostics.lastLocationAgeSeconds', 0);
         if (this.locationMqttStale[deviceId]) {
           this.locationMqttStale[deviceId] = false;
-          this.setState(deviceId + '.diagnostics.locationMqttStale', false, true);
+          this.setStateSafe(deviceId + '.diagnostics.locationMqttStale', false);
           this.log.info('MQTT location stream recovered: device=' + deviceId);
         }
       }
@@ -398,7 +404,7 @@ class Navimow extends utils.Adapter {
 
       // state channel: also store raw JSON
       if (channel === 'state') {
-        this.setState(deviceId + '.status.json', JSON.stringify(data), true);
+        this.setStateSafe(deviceId + '.status.json', JSON.stringify(data));
       }
 
       // location channel: collect points and render map
@@ -406,48 +412,17 @@ class Navimow extends utils.Adapter {
         const points = Array.isArray(data) ? data : [data];
 
         // Reset map when mowingPercentage=0 arrives (before collecting new points)
-        for (const p of points) {
-          if (p && p.mowingPercentage != null && Number(p.mowingPercentage) === 0) {
-            if (this.locationHistory[deviceId]?.length > 0) {
-              this.log.info(`mowingPercentage=0 via MQTT, resetting map for ${deviceId}`);
-              this.locationHistory[deviceId] = [];
-              this.setState(deviceId + '.map', '', true);
-            }
-            break;
-          }
+        if (hasMowingReset(points) && this.locationHistory[deviceId]?.length > 0) {
+          this.log.info(`mowingPercentage=0 via MQTT, resetting map for ${deviceId}`);
+          this.locationHistory[deviceId] = [];
+          this.setStateSafe(deviceId + '.map', '');
         }
 
         if (!this.locationHistory[deviceId]) {
           this.locationHistory[deviceId] = [];
         }
-        const history = this.locationHistory[deviceId];
-        const prevLen = history.length;
-        for (const p of points) {
-          if (p && p.postureX != null && p.postureY != null) {
-            const x = parseFloat(p.postureX);
-            const y = parseFloat(p.postureY);
-            if (isNaN(x) || isNaN(y)) continue;
-            const last = history[history.length - 1];
-            if (!last || last.x !== x || last.y !== y) {
-              history.push({ x, y });
-            }
-          }
-        }
-        if (history.length > prevLen) {
-          const now = Date.now();
-          if (!this.lastMapRender || now - this.lastMapRender >= 1000) {
-            this.lastMapRender = now;
-            this.renderMap(deviceId);
-          } else if (!this.mapRenderTimeout) {
-            this.mapRenderTimeout = this.setTimeout(() => {
-              this.mapRenderTimeout = null;
-              this.lastMapRender = Date.now();
-              this.renderMap(deviceId);
-            }, 1000 - (now - this.lastMapRender));
-          }
-        }
-        if (history.length > 5000) {
-          history.splice(0, history.length - 5000);
+        if (appendLocationPoints(this.locationHistory[deviceId], points, MAP_POINT_LIMIT) > 0) {
+          this.scheduleMapRender(deviceId);
         }
       }
 
@@ -458,15 +433,53 @@ class Navimow extends utils.Adapter {
       }
 
       const folderName = channel === 'state' ? 'status' : channel;
-      this.json2iob.parse(deviceId + '.' + folderName, data, {
-        forceIndex: true,
-        channelName: folderName.charAt(0).toUpperCase() + folderName.slice(1),
-        descriptions,
-        states,
-      });
+      this.json2iob
+        .parse(deviceId + '.' + folderName, data, {
+          forceIndex: true,
+          channelName: folderName.charAt(0).toUpperCase() + folderName.slice(1),
+          descriptions,
+          states,
+        })
+        .catch((e) => this.log.warn('MQTT ' + channel + ' state write failed: ' + e.message));
     } catch (e) {
       this.log.error('MQTT message parse error: ' + e.message);
     }
+  }
+
+  /**
+   * Write an acknowledged state without leaving an unhandled rejection behind.
+   * A rejected setState (restarting states DB, unloading adapter) would otherwise
+   * kill the adapter process.
+   *
+   * @param {string} id state id relative to the adapter namespace
+   * @param {any} value value to write
+   */
+  setStateSafe(id, value) {
+    this.setState(id, value, true).catch((e) => this.log.debug('setState ' + id + ' failed: ' + e.message));
+  }
+
+  /**
+   * Render the map at most once per MAP_RENDER_MIN_INTERVAL_MS and per device.
+   *
+   * @param {string} deviceId device the path belongs to
+   */
+  scheduleMapRender(deviceId) {
+    if (this.unloaded || this.mapRenderTimeout[deviceId]) {
+      return;
+    }
+    const now = Date.now();
+    const last = this.lastMapRender[deviceId] || 0;
+    const waitMs = MAP_RENDER_MIN_INTERVAL_MS - (now - last);
+    if (waitMs <= 0) {
+      this.lastMapRender[deviceId] = now;
+      this.renderMap(deviceId);
+      return;
+    }
+    this.mapRenderTimeout[deviceId] = this.setTimeout(() => {
+      delete this.mapRenderTimeout[deviceId];
+      this.lastMapRender[deviceId] = Date.now();
+      this.renderMap(deviceId);
+    }, waitMs);
   }
 
   /**
@@ -491,7 +504,7 @@ class Navimow extends utils.Adapter {
     };
     const activeCmd = stateToRemote[vehicleState] || null;
     for (const cmd of Object.keys(COMMAND_MAP)) {
-      this.setState(deviceId + '.remote.' + cmd, cmd === activeCmd, true);
+      this.setStateSafe(deviceId + '.remote.' + cmd, cmd === activeCmd);
     }
   }
 
@@ -566,7 +579,7 @@ class Navimow extends utils.Adapter {
     ctx.fill();
 
     const base64 = 'data:image/png;base64,' + canvas.toBuffer('image/png').toString('base64');
-    this.setState(deviceId + '.map', base64, true);
+    this.setStateSafe(deviceId + '.map', base64);
   }
 
   disconnectMqtt(suppressCredentialRefresh = false) {
@@ -610,10 +623,10 @@ class Navimow extends utils.Adapter {
     if (!active) {
       this.runningSince[deviceId] = 0;
       this.locationMqttStale[deviceId] = false;
-      this.setState(deviceId + '.diagnostics.locationMqttStale', false, true);
+      this.setStateSafe(deviceId + '.diagnostics.locationMqttStale', false);
       const lastLocation = this.lastLocationMessage[deviceId] || 0;
       const ageSeconds = lastLocation ? Math.round((now - lastLocation) / 1000) : 0;
-      this.setState(deviceId + '.diagnostics.lastLocationAgeSeconds', ageSeconds, true);
+      this.setStateSafe(deviceId + '.diagnostics.lastLocationAgeSeconds', ageSeconds);
       return;
     }
 
@@ -625,18 +638,18 @@ class Navimow extends utils.Adapter {
     const lastLocation = this.lastLocationMessage[deviceId] || 0;
     const locationAge = lastLocation ? now - lastLocation : activeAge;
     const ageSeconds = Math.round(locationAge / 1000);
-    this.setState(deviceId + '.diagnostics.lastLocationAgeSeconds', ageSeconds, true);
+    this.setStateSafe(deviceId + '.diagnostics.lastLocationAgeSeconds', ageSeconds);
 
     if (activeAge < LOCATION_STALE_MS || locationAge < LOCATION_STALE_MS) {
       if (this.locationMqttStale[deviceId]) {
         this.locationMqttStale[deviceId] = false;
-        this.setState(deviceId + '.diagnostics.locationMqttStale', false, true);
+        this.setStateSafe(deviceId + '.diagnostics.locationMqttStale', false);
       }
       return;
     }
 
     this.locationMqttStale[deviceId] = true;
-    this.setState(deviceId + '.diagnostics.locationMqttStale', true, true);
+    this.setStateSafe(deviceId + '.diagnostics.locationMqttStale', true);
 
     const lastRecovery = this.lastLocationRecovery[deviceId] || 0;
     if (now - lastRecovery < LOCATION_RECOVERY_COOLDOWN_MS) {
@@ -653,15 +666,15 @@ class Navimow extends utils.Adapter {
   }
 
   async recoverMqttLocationStream(deviceId) {
-    if (this.locationRecoveryRunning) {
-      this.log.debug('MQTT location recovery already running, skipping device=' + deviceId);
+    if (this.locationRecoveryRunning || this.unloaded) {
+      this.log.debug('MQTT location recovery already running or adapter unloading, skipping device=' + deviceId);
       return;
     }
 
     this.locationRecoveryRunning = true;
     const now = Date.now();
     this.lastLocationRecovery[deviceId] = now;
-    this.setState(deviceId + '.diagnostics.lastMqttRecovery', now, true);
+    this.setStateSafe(deviceId + '.diagnostics.lastMqttRecovery', now);
 
     try {
       await this.disconnectMqtt(true);
@@ -675,7 +688,7 @@ class Navimow extends utils.Adapter {
   }
 
   async refreshMqttCredentials() {
-    if (this.mqttRefreshing) return;
+    if (this.mqttRefreshing || this.unloaded) return;
     this.mqttRefreshing = true;
     try {
       // Refresh OAuth token first (MQTT credentials are bound to it)
@@ -798,10 +811,11 @@ class Navimow extends utils.Adapter {
     if (tokenData) {
       await this.storeToken(tokenData);
       this.log.info('Token refreshed successfully');
-      // Reconnect MQTT with new token
+      // Reconnect MQTT with new token. Both calls have to be awaited, otherwise the
+      // new client is created while the old one is still closing and wins the race.
       this.log.debug('Reconnecting MQTT with new token...');
-      this.disconnectMqtt();
-      this.connectMqtt();
+      await this.disconnectMqtt(true);
+      await this.connectMqtt();
       if (tokenData.expires_in) {
         const refreshMs = (tokenData.expires_in - 300) * 1000;
         if (refreshMs > 0) {
@@ -918,7 +932,7 @@ class Navimow extends utils.Adapter {
               native: {},
             });
           }
-          this.json2iob.parse(id + '.general', device, { descriptions, states });
+          await this.json2iob.parse(id + '.general', device, { descriptions, states });
         }
         this.log.info('Found ' + devices.length + ' device(s)');
       })
@@ -981,14 +995,16 @@ class Navimow extends utils.Adapter {
             if (v != null) deviceData.battery = v;
           }
 
-          this.setState(id + '.status.json', JSON.stringify(deviceData), true);
+          this.setStateSafe(id + '.status.json', JSON.stringify(deviceData));
 
-          this.json2iob.parse(id + '.status', deviceData, {
-            forceIndex: true,
-            channelName: 'Status',
-            descriptions,
-            states,
-          });
+          this.json2iob
+            .parse(id + '.status', deviceData, {
+              forceIndex: true,
+              channelName: 'Status',
+              descriptions,
+              states,
+            })
+            .catch((e) => this.log.warn('Status state write failed: ' + e.message));
 
           if (deviceData.vehicleState != null) {
             this.checkLocationWatchdog(id, deviceData.vehicleState);
@@ -1153,15 +1169,23 @@ class Navimow extends utils.Adapter {
     }
   }
 
-  onUnload(callback) {
+  async onUnload(callback) {
     try {
       this.log.debug('Adapter unloading, cleaning up...');
-      this.setState('info.connection', false, true);
-      this.disconnectMqtt();
-      this.updateInterval && clearInterval(this.updateInterval);
+      // Set before any await: every reconnect path checks this flag, otherwise the
+      // MQTT close handler rebuilds the connection while the adapter is shutting down.
+      this.unloaded = true;
+      this.updateInterval && this.clearInterval(this.updateInterval);
       this.refreshTokenTimeout && this.clearTimeout(this.refreshTokenTimeout);
       this.refreshTimeout && this.clearTimeout(this.refreshTimeout);
-      this.mapRenderTimeout && this.clearTimeout(this.mapRenderTimeout);
+      for (const handle of Object.values(this.mapRenderTimeout)) {
+        this.clearTimeout(handle);
+      }
+      this.mapRenderTimeout = {};
+      await this.setStateAsync('info.connection', false, true);
+      // In compact mode the process keeps running, so the client has to be gone
+      // before the callback returns.
+      await this.disconnectMqtt(true);
       callback();
     } catch {
       callback();

--- a/test/testMqttParse.js
+++ b/test/testMqttParse.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { expect } = require('chai');
+const { parseTopic, hasMowingReset, appendLocationPoints } = require('../lib/mqttParse');
+
+describe('mqttParse.parseTopic', () => {
+  it('extracts device id and channel from a realtime topic', () => {
+    expect(parseTopic('/downlink/vehicle/DEV1/realtimeDate/location')).to.deep.equal({
+      deviceId: 'DEV1',
+      channel: 'location',
+    });
+  });
+
+  it('works without the leading slash', () => {
+    expect(parseTopic('downlink/vehicle/DEV1/realtimeDate/state')).to.deep.equal({
+      deviceId: 'DEV1',
+      channel: 'state',
+    });
+  });
+
+  it('rejects foreign and truncated topics', () => {
+    expect(parseTopic('/uplink/vehicle/DEV1/realtimeDate/state')).to.equal(null);
+    expect(parseTopic('/downlink/robot/DEV1/realtimeDate/state')).to.equal(null);
+    expect(parseTopic('/downlink/vehicle/DEV1')).to.equal(null);
+    expect(parseTopic('')).to.equal(null);
+  });
+});
+
+describe('mqttParse.hasMowingReset', () => {
+  it('detects mowingPercentage 0 anywhere in the payload', () => {
+    expect(hasMowingReset([{ mowingPercentage: 12 }, { mowingPercentage: 0 }])).to.equal(true);
+    expect(hasMowingReset([{ mowingPercentage: '0' }])).to.equal(true);
+  });
+
+  it('ignores missing and non-zero values', () => {
+    expect(hasMowingReset([{ mowingPercentage: 12 }])).to.equal(false);
+    expect(hasMowingReset([{}, null])).to.equal(false);
+    expect(hasMowingReset([])).to.equal(false);
+  });
+});
+
+describe('mqttParse.appendLocationPoints', () => {
+  it('appends valid points and reports the count', () => {
+    const history = [];
+    const added = appendLocationPoints(history, [{ postureX: 1, postureY: 2 }, { postureX: '3', postureY: '4' }], 100);
+    expect(added).to.equal(2);
+    expect(history).to.deep.equal([
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ]);
+  });
+
+  it('skips repeated coordinates and unusable entries', () => {
+    const history = [{ x: 1, y: 2 }];
+    const added = appendLocationPoints(
+      history,
+      [{ postureX: 1, postureY: 2 }, { postureX: 'abc', postureY: 5 }, { postureX: null, postureY: 5 }, null],
+      100,
+    );
+    expect(added).to.equal(0);
+    expect(history).to.deep.equal([{ x: 1, y: 2 }]);
+  });
+
+  it('caps the history to the newest points', () => {
+    const history = [];
+    appendLocationPoints(
+      history,
+      Array.from({ length: 10 }, (_, i) => ({ postureX: i, postureY: i })),
+      4,
+    );
+    expect(history).to.deep.equal([
+      { x: 6, y: 6 },
+      { x: 7, y: 7 },
+      { x: 8, y: 8 },
+      { x: 9, y: 9 },
+    ]);
+  });
+});


### PR DESCRIPTION
Independent of the other open branches, each one applies to `main` on its own.

## MQTT

- **`keepalive` was 2400 seconds (40 minutes).** mqtt.js only notices a half-open socket through its keepalive pings, so a dead connection kept reporting "connected" for up to 40 minutes. This is the most likely root cause of the stalled location stream that the watchdog in #27 was built for. Now 60s. The watchdog stays in place - if it stops firing over a season it can be removed later.
- **Every device was subscribed five times**: the four explicit `realtimeDate/*` topics plus the `/#` wildcard that already covers them. Brokers deliver one copy per matching subscription, so every state write, every `json2iob.parse` and every map point was multiplied. Only the wildcard remains.
- `rejectUnauthorized` was set as a top level option, where it only applies to `mqtts`. Moved into `wsOptions`, so it now actually applies to the ws transport.
- `handleTokenRefresh` built the new client without awaiting the disconnect of the old one.

## Unload

The adapter declares `compact: true`, so anything left behind survives a stop.

- `onUnload` called back before the MQTT client was closed and left its reconnect timer running. It awaits `disconnectMqtt()` now.
- Added an `unloaded` flag checked by `connectMqtt`, `refreshMqttCredentials`, `recoverMqttLocationStream` and the map render scheduler, so no path rebuilds a connection during shutdown.
- Plain `setInterval`/`clearInterval` replaced by the adapter wrappers (repochecker E5004).

## Map rendering

`lastMapRender` and `mapRenderTimeout` were single values shared by all devices, so with two mowers one of them regularly lost its scheduled render. Both are keyed by device now, and all pending timers are cleared on unload.

## Unhandled rejections

`setState` and `json2iob.parse` results were dropped on the floor. A rejected write (states DB restarting) becomes an unhandled rejection and takes the adapter process down. Added `setStateSafe()` plus catch handlers on the parse calls.

## Tests

Topic parsing, mowing reset detection and location point collection moved to `lib/mqttParse.js` with unit tests in `test/testMqttParse.js` (9 cases: foreign/truncated topics, NaN coordinates, duplicate points, history cap).

Checks: `npm run check`, `npm run lint`, `npm test`, `npm pack --dry-run` pass.
