### PR TITLE
feat!: keep tokens and rendered maps in the adapter file storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Periodic HTTP polling refreshes general status values (for example battery, stat
 
 The token is refreshed automatically. A re-login is only needed if the refresh token expires.
 
+Access and refresh token are stored in the adapter's own file storage (`session.json`), not in a state. Installations coming from version 1.0.2 or older migrate the content of `auth.token` automatically on the first start; the state and its channel are removed afterwards.
+
 The **Update interval** setting defines the periodic HTTP status polling interval in minutes (minimum: 1 minute). MQTT stays active in parallel for real-time updates.
 
 ## States
@@ -129,7 +131,9 @@ If HTTP polling reports an active mowing state but no MQTT `location` message is
 
 ### Mowing Map
 
-The adapter renders a live mowing map as a PNG image (base64 data URI) in the state `{deviceId}.map`. The map is automatically updated during mowing and cleared when a new mowing session starts.
+The adapter renders a live mowing map as a PNG file into its own file storage and puts the URL of that file into the state `{deviceId}.map`, for example `/files/navimow.0/map/DEVICE_ID.png`. The map is automatically updated during mowing and cleared when a new mowing session starts.
+
+Image widgets in VIS can use the state value directly as image source. Scripts that read the state expecting a `data:image/png;base64,...` value (the format used up to version 1.0.2) have to be adjusted.
 
 #### VIS Position Script
 

--- a/io-package.json
+++ b/io-package.json
@@ -125,7 +125,9 @@
     ]
   },
   "encryptedNative": [],
-  "protectedNative": [],
+  "protectedNative": [
+    "authCode"
+  ],
   "native": {
     "authCode": "",
     "interval": 5

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Parse a stored session. Accepts what the file storage returns (Buffer or string)
+ * as well as the legacy `auth.token` state value, which was either the token JSON
+ * or, in very old installations, a bare access token.
+ *
+ * @param {any} raw file content or state value
+ * @returns {Record<string, any> | null} session object or null if unusable
+ */
+function parseSession(raw) {
+  if (raw == null) {
+    return null;
+  }
+  const text = Buffer.isBuffer(raw) ? raw.toString('utf8') : String(raw);
+  if (!text.trim()) {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Legacy: the state held the bare access token
+    return { access_token: text };
+  }
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed) && parsed.access_token) {
+    return parsed;
+  }
+  return null;
+}
+
+/**
+ * File name of the rendered map inside the adapter file storage.
+ *
+ * @param {string} deviceId sanitized device id
+ * @returns {string} path relative to the adapter file storage
+ */
+function mapFileName(deviceId) {
+  return 'map/' + deviceId + '.png';
+}
+
+/**
+ * URL of the rendered map, as served by admin and web.
+ *
+ * @param {string} namespace adapter namespace, e.g. navimow.0
+ * @param {string} deviceId sanitized device id
+ * @returns {string} URL for the map state
+ */
+function mapUrl(namespace, deviceId) {
+  return '/files/' + namespace + '/' + mapFileName(deviceId);
+}
+
+module.exports = { parseSession, mapFileName, mapUrl };

--- a/main.js
+++ b/main.js
@@ -9,6 +9,11 @@ const { URL } = require('url');
 const { createCanvas } = require('@napi-rs/canvas');
 const descriptions = require('./lib/descriptions.json');
 const states = require('./lib/states.json');
+const { parseSession, mapFileName, mapUrl } = require('./lib/session');
+
+// Tokens live in the adapter file storage, not in a state: states are visible in the
+// object browser and end up in every object dump a user attaches to an issue.
+const SESSION_FILE = 'session.json';
 
 const API_BASE_URL = 'https://navimow-fra.ninebot.com';
 const OAUTH2_TOKEN_URL = API_BASE_URL + '/openapi/oauth/getAccessToken';
@@ -82,14 +87,10 @@ class Navimow extends utils.Adapter {
 
     this.subscribeStates('*');
 
-    await this.setObjectNotExistsAsync('auth', {
-      type: 'channel',
-      common: { name: 'Authentication' },
-      native: {},
-    });
-    await this.setObjectNotExistsAsync('auth.token', {
-      type: 'state',
-      common: { name: 'Token Data', type: 'string', role: 'json', read: true, write: false },
+    // Container object for the adapter file storage (session and rendered maps)
+    await this.setForeignObjectNotExistsAsync(this.namespace, {
+      type: 'meta',
+      common: { name: 'navimow files', type: 'meta.user' },
       native: {},
     });
 
@@ -122,15 +123,9 @@ class Navimow extends utils.Adapter {
 
     // Step 2: Restore stored token and try refresh
     this.log.debug('Loading stored token...');
-    const tokenState = await this.getStateAsync('auth.token');
-    if (tokenState && tokenState.val) {
-      let tokenObj;
-      try {
-        tokenObj = JSON.parse(/** @type {string} */ (tokenState.val));
-      } catch {
-        tokenObj = { access_token: tokenState.val };
-      }
-
+    const storedSession = (await this.loadSession()) || (await this.migrateTokenState());
+    if (storedSession) {
+      let tokenObj = storedSession;
       if (tokenObj.refresh_token) {
         this.log.info('Refresh token found, trying to refresh...');
         const refreshed = await this.refreshToken(tokenObj.refresh_token);
@@ -565,8 +560,11 @@ class Navimow extends utils.Adapter {
     ctx.arc(padding + (last.x - minX) * scaleX, padding + (maxY - last.y) * scaleY, 5, 0, Math.PI * 2);
     ctx.fill();
 
-    const base64 = 'data:image/png;base64,' + canvas.toBuffer('image/png').toString('base64');
-    this.setState(deviceId + '.map', base64, true);
+    // The PNG goes into the adapter file storage; a ~60 kB data URI written through the
+    // states database (and every history adapter) once per second was expensive.
+    this.writeFileAsync(this.namespace, mapFileName(deviceId), canvas.toBuffer('image/png'))
+      .then(() => this.setState(deviceId + '.map', mapUrl(this.namespace, deviceId), true))
+      .catch((e) => this.log.warn('Writing the map file failed: ' + e.message));
   }
 
   disconnectMqtt(suppressCredentialRefresh = false) {
@@ -720,8 +718,52 @@ class Navimow extends utils.Adapter {
 
   async storeToken(tokenData) {
     this.session = tokenData;
-    await this.setStateAsync('auth.token', { val: JSON.stringify(tokenData), ack: true });
+    await this.writeFileAsync(this.namespace, SESSION_FILE, JSON.stringify(tokenData));
     this.log.info('Token stored');
+  }
+
+  /**
+   * Read the stored session from the adapter file storage.
+   *
+   * @returns {Promise<Record<string, any> | null>} session or null if there is none
+   */
+  async loadSession() {
+    try {
+      const res = await this.readFileAsync(this.namespace, SESSION_FILE);
+      return parseSession(res && typeof res === 'object' && 'file' in res ? res.file : res);
+    } catch {
+      // No session file yet
+      return null;
+    }
+  }
+
+  /**
+   * One time migration: older versions kept the tokens in the state auth.token,
+   * where they were visible in the object browser and in every object dump.
+   *
+   * @returns {Promise<Record<string, any> | null>} migrated session or null
+   */
+  async migrateTokenState() {
+    let session;
+    try {
+      const tokenState = await this.getStateAsync('auth.token');
+      session = parseSession(tokenState && tokenState.val);
+      if (session) {
+        await this.writeFileAsync(this.namespace, SESSION_FILE, JSON.stringify(session));
+        this.log.info('Token moved from the state auth.token into the adapter file storage');
+      }
+    } catch (e) {
+      this.log.warn('Token migration failed: ' + e.message);
+      return null;
+    }
+    for (const id of ['auth.token', 'auth']) {
+      try {
+        await this.delObjectAsync(id);
+      } catch {
+        // Object does not exist (fresh installation)
+      }
+    }
+    return session ?? null;
   }
 
   getAuthHeaders() {
@@ -867,8 +909,13 @@ class Navimow extends utils.Adapter {
           });
           await this.setObjectNotExistsAsync(id + '.map', {
             type: 'state',
-            common: { name: 'Mowing Map (PNG base64)', write: false, read: true, type: 'string', role: 'text' },
+            common: { name: 'Mowing map (URL)', write: false, read: true, type: 'string', role: 'text.url' },
             native: {},
+          });
+          // Installations created before the map moved into the file storage still
+          // describe the state as a base64 image
+          await this.extendObjectAsync(id + '.map', {
+            common: { name: 'Mowing map (URL)', role: 'text.url' },
           });
           await this.setObjectNotExistsAsync(id + '.diagnostics', {
             type: 'channel',

--- a/test/testSession.js
+++ b/test/testSession.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { expect } = require('chai');
+const { parseSession, mapFileName, mapUrl } = require('../lib/session');
+
+describe('session.parseSession', () => {
+  it('reads a session written as JSON string', () => {
+    expect(parseSession('{"access_token":"a","refresh_token":"r","expires_in":3600}')).to.deep.equal({
+      access_token: 'a',
+      refresh_token: 'r',
+      expires_in: 3600,
+    });
+  });
+
+  it('reads a session delivered as Buffer by the file storage', () => {
+    expect(parseSession(Buffer.from('{"access_token":"a"}', 'utf8'))).to.deep.equal({ access_token: 'a' });
+  });
+
+  it('accepts the legacy state value that held a bare access token', () => {
+    expect(parseSession('plain-token-value')).to.deep.equal({ access_token: 'plain-token-value' });
+  });
+
+  it('rejects empty, missing and structurally unusable input', () => {
+    expect(parseSession(null)).to.equal(null);
+    expect(parseSession(undefined)).to.equal(null);
+    expect(parseSession('')).to.equal(null);
+    expect(parseSession('   ')).to.equal(null);
+    expect(parseSession('{}')).to.equal(null);
+    expect(parseSession('{"refresh_token":"r"}')).to.equal(null);
+    expect(parseSession('[1,2,3]')).to.equal(null);
+  });
+});
+
+describe('session map paths', () => {
+  it('builds file name and URL from the sanitized device id', () => {
+    expect(mapFileName('DEV1')).to.equal('map/DEV1.png');
+    expect(mapUrl('navimow.0', 'DEV1')).to.equal('/files/navimow.0/map/DEV1.png');
+  });
+});


### PR DESCRIPTION
Independent of the other open branches. **Contains two breaking changes**, both deliberate:

- the state `{deviceId}.map` holds a URL instead of a base64 data URI
- the state `auth.token` is removed after a one time migration

## Tokens

Access and refresh token were stored as plain JSON in the state `auth.token`. That state is visible in the object browser to every user and it is part of every object dump people attach to a GitHub issue - a valid refresh token included.

They now live in `session.json` inside the adapter's own file storage.

Why not `encryptedNative`: writing the own instance object restarts the adapter, and the token is refreshed roughly every hour.

**Migration** happens on the first start: `auth.token` is read once, written to the file storage, then the state and its `auth` channel are deleted. Users do not have to log in again. The legacy case where the state held a bare access token instead of JSON is handled too.

`authCode` is now declared `protectedNative`, so it is no longer handed out to non-admin UI clients.

## Map

The rendered PNG (~40-80 kB as a data URI) was written into the states database up to once per second, and from there into every history adapter and every object export.

It is written into the file storage now; the state holds `/files/navimow.0/map/<device>.png` and gets `role: text.url`. Existing `.map` objects are updated via `extendObject`, since their name and role described a base64 image.

- Image widgets in VIS can keep using the state value as image source
- scripts that read the state expecting `data:image/png;base64,...` need adjusting - noted in the README

Follow-up worth doing after #31 is merged: raise the render throttle from 1 s to 5 s. That constant only exists on that branch, so this PR leaves it alone.

## Tests

`parseSession` and the map path helpers live in `lib/session.js`, covered by `test/testSession.js`: Buffer input from the file storage, the legacy bare token, empty and structurally unusable content.

Checks: `npm run check`, `npm run lint`, `npm test`, `npm pack --dry-run` pass.

:information_source: The object dump verification (`checkObjectStructure`) for the changed `.map` role should run against a real instance of this branch before a repository PR - I cannot produce that dump here.
