### PR TITLE
fix: run the location watchdog on its own timer in MQTT-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The `diagnostics` channel contains read-only values for the MQTT location watchd
 | `diagnostics.lastMqttRecovery`       | Timestamp of the last controlled MQTT recovery   |
 | `diagnostics.lastLocationAgeSeconds` | Age of the last MQTT location message in seconds |
 
-If HTTP polling reports an active mowing state but no MQTT `location` message is received for at least three minutes, the adapter marks the location stream as stale and reconnects MQTT. Recoveries are rate-limited to at most once every five minutes per device. Battery, status and `vehicleState` continue to be updated by periodic HTTP polling independently from this watchdog.
+If an active mowing state is reported but no MQTT `location` message is received for at least three minutes, the adapter marks the location stream as stale and reconnects MQTT. Recoveries are rate-limited to at most once every five minutes per device. The check normally runs inside the HTTP status poll; with the polling interval set to `0` (MQTT only) it runs on its own one minute timer using the last vehicle state received via MQTT. Battery, status and `vehicleState` continue to be updated by periodic HTTP polling independently from this watchdog.
 
 ### Mowing Map
 

--- a/main.js
+++ b/main.js
@@ -18,6 +18,8 @@ const REDIRECT_URI = 'http://localhost:1/callback';
 
 
 // Location MQTT watchdog
+// With interval=0 there is no HTTP poll to drive the watchdog, so it runs on its own timer
+const LOCATION_WATCHDOG_INTERVAL_MS = 60 * 1000;
 const LOCATION_STALE_MS = 3 * 60 * 1000;
 const LOCATION_RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
 const ACTIVE_LOCATION_STATES = new Set(['isRunning', 'mowing', 'isMowing', 'isMapping', 'mapping']);
@@ -49,6 +51,7 @@ class Navimow extends utils.Adapter {
     });
     this.session = {};
     this.updateInterval = null;
+    this.watchdogInterval = null;
     this.refreshTokenTimeout = null;
     this.refreshTimeout = undefined;
     this.mqttClient = null;
@@ -164,6 +167,12 @@ class Navimow extends utils.Adapter {
           this.updateInterval = setInterval(() => this.pollDevices('interval'), pollMs);
         } else {
           this.log.info('Periodic HTTP status polling disabled (interval=0). Relying on MQTT for updates.');
+          // The watchdog normally runs inside the HTTP poll. Without polling it needs its
+          // own timer, otherwise a stalled location stream is never noticed in MQTT-only mode.
+          this.watchdogInterval = this.setInterval(
+            () => this.runLocationWatchdog(),
+            LOCATION_WATCHDOG_INTERVAL_MS,
+          );
         }
 
         // Schedule token refresh
@@ -597,6 +606,19 @@ class Navimow extends utils.Adapter {
       client.end(true, finish);
       timeoutHandle = this.setTimeout(finish, 2000);
     }));
+  }
+
+  /**
+   * Check every known device against the last vehicle state seen via MQTT.
+   * Used only in MQTT-only mode (interval=0).
+   */
+  runLocationWatchdog() {
+    for (const deviceId of this.deviceArray) {
+      const vehicleState = this.lastVehicleState[deviceId];
+      if (vehicleState) {
+        this.checkLocationWatchdog(deviceId, vehicleState);
+      }
+    }
   }
 
   isLocationActiveState(vehicleState) {
@@ -1159,6 +1181,7 @@ class Navimow extends utils.Adapter {
       this.setState('info.connection', false, true);
       this.disconnectMqtt();
       this.updateInterval && clearInterval(this.updateInterval);
+      this.watchdogInterval && this.clearInterval(this.watchdogInterval);
       this.refreshTokenTimeout && this.clearTimeout(this.refreshTokenTimeout);
       this.refreshTimeout && this.clearTimeout(this.refreshTimeout);
       this.mapRenderTimeout && this.clearTimeout(this.mapRenderTimeout);


### PR DESCRIPTION
Independent of the other open branches.

`checkLocationWatchdog()` is only called from the HTTP status poll. The admin UI offers `interval = 0` as "MQTT only", and in that mode the watchdog never ran at all - exactly the configuration where a stalled MQTT location stream hurts most, because there is no HTTP fallback delivering status either.

With `interval = 0` the adapter now starts a one minute timer that checks every known device against the last vehicle state received via MQTT (`lastVehicleState`). With polling enabled nothing changes - the poll keeps driving the watchdog, and no second timer is started.

Checks: `npm run check`, `npm run lint`, `npm test` pass.
