### PR TITLE
fix: refresh status over HTTP when MQTT goes quiet in MQTT-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The token is refreshed automatically. A re-login is only needed if the refresh t
 
 The **Update interval** setting defines the periodic HTTP status polling interval in minutes (minimum: 1 minute). MQTT stays active in parallel for real-time updates.
 
+Setting the interval to `0` disables periodic polling and relies on MQTT alone. Because the broker only pushes the `state` channel while the mower is operating, the adapter still performs a single HTTP status poll whenever no MQTT status update has arrived for 15 minutes. Without that fallback, battery and `vehicleState` would keep their last values for hours while the mower is docked and charging.
+
 ## States
 
 For each mower device the following channels are created:

--- a/main.js
+++ b/main.js
@@ -20,6 +20,13 @@ const REDIRECT_URI = 'http://localhost:1/callback';
 // Location MQTT watchdog
 const LOCATION_STALE_MS = 3 * 60 * 1000;
 const LOCATION_RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
+
+// MQTT-only mode (interval=0): the broker only pushes the state channel while the
+// mower is moving. Docked and charging it stays silent, so battery and vehicleState
+// keep their last values for hours. Fall back to a single HTTP poll once the state
+// channel has been quiet for this long.
+const STATUS_STALE_MS = 15 * 60 * 1000;
+const STATUS_STALE_CHECK_MS = 60 * 1000;
 const ACTIVE_LOCATION_STATES = new Set(['isRunning', 'mowing', 'isMowing', 'isMapping', 'mapping']);
 
 // Command mapping: name -> { command, params }
@@ -49,6 +56,8 @@ class Navimow extends utils.Adapter {
     });
     this.session = {};
     this.updateInterval = null;
+    this.statusStaleInterval = null;
+    this.lastStatusUpdate = 0;
     this.refreshTokenTimeout = null;
     this.refreshTimeout = undefined;
     this.mqttClient = null;
@@ -163,7 +172,12 @@ class Navimow extends utils.Adapter {
           );
           this.updateInterval = setInterval(() => this.pollDevices('interval'), pollMs);
         } else {
-          this.log.info('Periodic HTTP status polling disabled (interval=0). Relying on MQTT for updates.');
+          this.log.info(
+            'Periodic HTTP status polling disabled (interval=0). Relying on MQTT, with an HTTP fallback poll after ' +
+              Math.round(STATUS_STALE_MS / 60000) +
+              ' minutes without a status update.',
+          );
+          this.statusStaleInterval = this.setInterval(() => this.pollIfStatusStale(), STATUS_STALE_CHECK_MS);
         }
 
         // Schedule token refresh
@@ -398,6 +412,7 @@ class Navimow extends utils.Adapter {
 
       // state channel: also store raw JSON
       if (channel === 'state') {
+        this.lastStatusUpdate = Date.now();
         this.setState(deviceId + '.status.json', JSON.stringify(data), true);
       }
 
@@ -981,6 +996,7 @@ class Navimow extends utils.Adapter {
             if (v != null) deviceData.battery = v;
           }
 
+          this.lastStatusUpdate = Date.now();
           this.setState(id + '.status.json', JSON.stringify(deviceData), true);
 
           this.json2iob.parse(id + '.status', deviceData, {
@@ -1005,6 +1021,23 @@ class Navimow extends utils.Adapter {
         this.log.error('updateDevices error: ' + error.message);
         error.response && this.log.error(JSON.stringify(error.response.data));
       });
+  }
+
+  /**
+   * MQTT-only fallback: pull the status over HTTP when the MQTT state channel has
+   * gone quiet. Without this, battery and vehicleState freeze while the mower is
+   * docked, because the broker only pushes the state channel during operation.
+   */
+  pollIfStatusStale() {
+    const age = Date.now() - this.lastStatusUpdate;
+    if (age < STATUS_STALE_MS) {
+      return;
+    }
+    this.log.debug('No MQTT status update for ' + Math.round(age / 60000) + ' min, falling back to HTTP poll');
+    // Count the attempt, not just the success. A failing poll otherwise leaves the
+    // timestamp stale and this check would retry every minute instead of every 15.
+    this.lastStatusUpdate = Date.now();
+    this.pollDevices('status stale');
   }
 
   async pollDevices(reason) {
@@ -1159,6 +1192,7 @@ class Navimow extends utils.Adapter {
       this.setState('info.connection', false, true);
       this.disconnectMqtt();
       this.updateInterval && clearInterval(this.updateInterval);
+      this.statusStaleInterval && this.clearInterval(this.statusStaleInterval);
       this.refreshTokenTimeout && this.clearTimeout(this.refreshTokenTimeout);
       this.refreshTimeout && this.clearTimeout(this.refreshTimeout);
       this.mapRenderTimeout && this.clearTimeout(this.mapRenderTimeout);


### PR DESCRIPTION
Fixes #16.

### Problem

With `interval=0` the adapter relies entirely on MQTT. The broker only pushes the `state` channel while the mower is operating — once it is docked and charging, nothing arrives, so `battery` and `vehicleState` keep their last values for hours. That is exactly what is reported in #16 (and matches @disaster123's observation there that only the `location` topic updates on its own).

The existing location watchdog does not cover this: `checkLocationWatchdog()` returns early unless `vehicleState` is in `ACTIVE_LOCATION_STATES`. While charging it is not, so the watchdog is inactive in precisely the reported scenario — and reconnecting MQTT would not produce a `state` message anyway.

### Change

- Track `lastStatusUpdate` where a status actually arrives: the MQTT `state` channel and `updateDevices()`.
- `pollIfStatusStale()` runs one HTTP status poll when that timestamp is older than 15 minutes.
- The check runs once a minute and **only** when `interval=0`. With `interval > 0` there is no behaviour change at all.
- The timestamp is updated before the poll, so a failing poll retries after 15 minutes instead of every minute.
- `clearInterval` in `onUnload`.

Since `updateDevices()` already calls `checkLocationWatchdog()`, the fallback poll also drives the location watchdog in MQTT-only mode — no second timer needed.

### Notes

- 2 files, +37/-1. `keepalive: 2400` and everything else is untouched.
- `npx eslint main.js`, `npx tsc --noEmit` and `npm run test:js` pass.
- 15 minutes is a compromise between a fresh battery value and API load (4 requests/hour while docked). Happy to change the constant if you prefer a different value.
