### PR TITLE
chore: fix repochecker findings in io-package.json (issue #11)

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -41,19 +41,6 @@
         "pl": "początkowe zwolnienie",
         "uk": "початковий реліз",
         "zh-cn": "初步释放"
-      },
-      "0.0.1": {
-        "en": "initial release",
-        "de": "Erstveröffentlichung",
-        "ru": "Начальная версия",
-        "pt": "lançamento inicial",
-        "nl": "Eerste uitgave",
-        "fr": "Première version",
-        "it": "Versione iniziale",
-        "es": "Versión inicial",
-        "pl": "Pierwsze wydanie",
-        "uk": "Початкова версія",
-        "zh-cn": "首次出版"
       }
     },
     "titleLang": {
@@ -120,7 +107,7 @@
     ],
     "globalDependencies": [
       {
-        "admin": ">=7.6.17"
+        "admin": ">=7.6.20"
       }
     ]
   },


### PR DESCRIPTION
Two of the items the ioBroker check bot reported in #11, io-package.json only, +1/-14.

**E2004** — `common.news` listed `0.0.1`. That version was never published; npm has `1.0.0`, `1.0.1`, `1.0.2` only. The checker treats this as an error that can block stable-repo updates, so the entry is removed.

**W1056** — `globalDependencies` pinned `admin >=7.6.17`, recommended is `>=7.6.20`.

Not touched:
- **E2001** (`npm owner add bluefox`) can only be done by the npm package owner.
- **W5015** (i18n disabled in jsonConfig) would mean extracting every text into `admin/i18n/*.json` — separate PR if you want it at all, the inline `en`/`de` texts work today.
- The eslint-config / adapter-dev / workflow suggestions are optional and out of scope here.

`npm run test:package` passes.