### PR TITLE
feat: keep OAuth tokens in the adapter file storage instead of a state

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Periodic HTTP polling refreshes general status values (for example battery, stat
 
 The token is refreshed automatically. A re-login is only needed if the refresh token expires.
 
+Access and refresh token are stored in the adapter's own file storage (`session.json`), not in a state. Installations coming from version 1.0.2 or older migrate the content of `auth.token` automatically on the first start; the state and its channel are removed afterwards.
+
 The **Update interval** setting defines the periodic HTTP status polling interval in minutes (minimum: 1 minute). MQTT stays active in parallel for real-time updates.
 
 Setting the interval to `0` disables periodic polling and relies on MQTT alone. Because the broker only pushes the `state` channel while the mower is operating, the adapter still performs a single HTTP status poll whenever no MQTT status update has arrived for 15 minutes. Without that fallback, battery and `vehicleState` would keep their last values for hours while the mower is docked and charging.

--- a/io-package.json
+++ b/io-package.json
@@ -112,7 +112,9 @@
     ]
   },
   "encryptedNative": [],
-  "protectedNative": [],
+  "protectedNative": [
+    "authCode"
+  ],
   "native": {
     "authCode": "",
     "interval": 5

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Parse a stored session. Accepts what the file storage returns (Buffer or string)
+ * as well as the legacy `auth.token` state value, which was either the token JSON
+ * or, in very old installations, a bare access token.
+ *
+ * @param {any} raw file content or state value
+ * @returns {Record<string, any> | null} session object or null if unusable
+ */
+function parseSession(raw) {
+  if (raw == null) {
+    return null;
+  }
+  const text = Buffer.isBuffer(raw) ? raw.toString('utf8') : String(raw);
+  if (!text.trim()) {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Legacy: the state held the bare access token
+    return { access_token: text };
+  }
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed) && parsed.access_token) {
+    return parsed;
+  }
+  return null;
+}
+
+module.exports = { parseSession };

--- a/main.js
+++ b/main.js
@@ -9,6 +9,11 @@ const { URL } = require('url');
 const { createCanvas } = require('@napi-rs/canvas');
 const descriptions = require('./lib/descriptions.json');
 const states = require('./lib/states.json');
+const { parseSession } = require('./lib/session');
+
+// Tokens live in the adapter file storage, not in a state: states are visible in the
+// object browser and end up in every object dump a user attaches to an issue.
+const SESSION_FILE = 'session.json';
 
 const API_BASE_URL = 'https://navimow-fra.ninebot.com';
 const OAUTH2_TOKEN_URL = API_BASE_URL + '/openapi/oauth/getAccessToken';
@@ -92,14 +97,10 @@ class Navimow extends utils.Adapter {
 
     this.subscribeStates('*');
 
-    await this.setObjectNotExistsAsync('auth', {
-      type: 'channel',
-      common: { name: 'Authentication' },
-      native: {},
-    });
-    await this.setObjectNotExistsAsync('auth.token', {
-      type: 'state',
-      common: { name: 'Token Data', type: 'string', role: 'json', read: true, write: false },
+    // Container object for the adapter file storage (session.json)
+    await this.setForeignObjectNotExistsAsync(this.namespace, {
+      type: 'meta',
+      common: { name: 'navimow files', type: 'meta.user' },
       native: {},
     });
 
@@ -132,14 +133,9 @@ class Navimow extends utils.Adapter {
 
     // Step 2: Restore stored token and try refresh
     this.log.debug('Loading stored token...');
-    const tokenState = await this.getStateAsync('auth.token');
-    if (tokenState && tokenState.val) {
-      let tokenObj;
-      try {
-        tokenObj = JSON.parse(/** @type {string} */ (tokenState.val));
-      } catch {
-        tokenObj = { access_token: tokenState.val };
-      }
+    const storedSession = (await this.loadSession()) || (await this.migrateTokenState());
+    if (storedSession) {
+      let tokenObj = storedSession;
 
       if (tokenObj.refresh_token) {
         this.log.info('Refresh token found, trying to refresh...');
@@ -756,8 +752,52 @@ class Navimow extends utils.Adapter {
 
   async storeToken(tokenData) {
     this.session = tokenData;
-    await this.setStateAsync('auth.token', { val: JSON.stringify(tokenData), ack: true });
+    await this.writeFileAsync(this.namespace, SESSION_FILE, JSON.stringify(tokenData));
     this.log.info('Token stored');
+  }
+
+  /**
+   * Read the stored session from the adapter file storage.
+   *
+   * @returns {Promise<Record<string, any> | null>} session or null if there is none
+   */
+  async loadSession() {
+    try {
+      const res = await this.readFileAsync(this.namespace, SESSION_FILE);
+      return parseSession(res && typeof res === 'object' && 'file' in res ? res.file : res);
+    } catch {
+      // No session file yet
+      return null;
+    }
+  }
+
+  /**
+   * One time migration: older versions kept the tokens in the state auth.token,
+   * where they were visible in the object browser and in every object dump.
+   *
+   * @returns {Promise<Record<string, any> | null>} migrated session or null
+   */
+  async migrateTokenState() {
+    let session;
+    try {
+      const tokenState = await this.getStateAsync('auth.token');
+      session = parseSession(tokenState && tokenState.val);
+      if (session) {
+        await this.writeFileAsync(this.namespace, SESSION_FILE, JSON.stringify(session));
+        this.log.info('Token moved from the state auth.token into the adapter file storage');
+      }
+    } catch (e) {
+      this.log.warn('Token migration failed: ' + e.message);
+      return null;
+    }
+    for (const id of ['auth.token', 'auth']) {
+      try {
+        await this.delObjectAsync(id);
+      } catch {
+        // Object does not exist (fresh installation)
+      }
+    }
+    return session ?? null;
   }
 
   getAuthHeaders() {

--- a/test/testSession.js
+++ b/test/testSession.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { expect } = require('chai');
+const { parseSession } = require('../lib/session');
+
+describe('session.parseSession', () => {
+  it('reads a session written as JSON string', () => {
+    expect(parseSession('{"access_token":"a","refresh_token":"r","expires_in":3600}')).to.deep.equal({
+      access_token: 'a',
+      refresh_token: 'r',
+      expires_in: 3600,
+    });
+  });
+
+  it('reads a session delivered as Buffer by the file storage', () => {
+    expect(parseSession(Buffer.from('{"access_token":"a"}', 'utf8'))).to.deep.equal({ access_token: 'a' });
+  });
+
+  it('accepts the legacy state value that held a bare access token', () => {
+    expect(parseSession('plain-token-value')).to.deep.equal({ access_token: 'plain-token-value' });
+  });
+
+  it('rejects empty, missing and structurally unusable input', () => {
+    expect(parseSession(null)).to.equal(null);
+    expect(parseSession(undefined)).to.equal(null);
+    expect(parseSession('')).to.equal(null);
+    expect(parseSession('   ')).to.equal(null);
+    expect(parseSession('{}')).to.equal(null);
+    expect(parseSession('{"refresh_token":"r"}')).to.equal(null);
+    expect(parseSession('[1,2,3]')).to.equal(null);
+  });
+});


### PR DESCRIPTION
Re-cut of the token half of #35. Smaller and without the map change: the state `{deviceId}.map` and its data URI stay exactly as they are today.

Note on #35: the closing comment there was about the location watchdog ("only monitors the position stream ... battery not updating with interval=0"), which is #36. It does not apply to this change, so I am bringing the token part back on its own.

## What it does

Access and refresh token were stored as plain JSON in the state `auth.token`. That state is visible in the object browser to every user and it ends up in every object dump people attach to a GitHub issue, valid refresh token included. They move into `session.json` in the adapter's own file storage.

Why not `encryptedNative`: writing the own instance object restarts the adapter, and the token is refreshed roughly every hour.

**Migration** runs on the first start: `auth.token` is read once, written to the file storage, then the state and the `auth` channel are deleted. Nobody has to log in again. The old case where the state held a bare access token instead of JSON is handled too.

`authCode` is declared `protectedNative`, so it is no longer handed to non-admin UI clients.

## Not in here

- the map moving out of the states database (the breaking half of #35)
- any change to logging, MQTT or the poll logic

## Tests

`parseSession` is in `lib/session.js`, covered by `test/testSession.js`: Buffer input from the file storage, the legacy bare token, empty and structurally unusable content.

`npx eslint main.js`, `npx tsc --noEmit`, `npm run test:js` and `npm run test:package` pass. +126/-18 across 5 files.
