### PR TITLE
fix: clamp the configured HTTP polling interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Periodic HTTP polling refreshes general status values (for example battery, stat
 
 The token is refreshed automatically. A re-login is only needed if the refresh token expires.
 
-The **Update interval** setting defines the periodic HTTP status polling interval in minutes (minimum: 1 minute). MQTT stays active in parallel for real-time updates.
+The **Update interval** setting defines the periodic HTTP status polling interval in minutes (minimum: 1 minute, maximum: 1440; values in between are rounded to whole minutes). MQTT stays active in parallel for real-time updates.
 
 Setting the interval to `0` disables periodic polling and relies on MQTT alone. Because the broker only pushes the `state` channel while the mower is operating, the adapter still performs a single HTTP status poll whenever no MQTT status update has arrived for 15 minutes. Without that fallback, battery and `vehicleState` would keep their last values for hours while the mower is docked and charging.
 

--- a/main.js
+++ b/main.js
@@ -86,8 +86,19 @@ class Navimow extends utils.Adapter {
     if (!Number.isFinite(configuredInterval) || configuredInterval < 0) {
       this.log.info('Invalid interval, defaulting to 5 minutes');
       this.config.interval = 5;
+    } else if (configuredInterval === 0) {
+      this.config.interval = 0;
     } else {
-      this.config.interval = configuredInterval;
+      // Fractional minutes hammer the cloud API (0.1 polls every 6 seconds) and a
+      // value above 35791 minutes overflows the 32 bit delay of setInterval, which
+      // then fires continuously instead of never. One day is well beyond any useful
+      // polling rate and stays clear of that limit.
+      this.config.interval = Math.min(1440, Math.max(1, Math.round(configuredInterval)));
+      if (this.config.interval !== configuredInterval) {
+        this.log.info(
+          'Polling interval ' + configuredInterval + ' adjusted to ' + this.config.interval + ' minute(s)',
+        );
+      }
     }
 
     this.subscribeStates('*');


### PR DESCRIPTION
The admin UI only sets `min: 0` on the interval field, so a fractional or very large value is passed to `setInterval` unchanged:

- `0.1` polls `getVehicleStatus` every 6 seconds.
- anything above 35791 minutes exceeds the 32 bit delay of `setInterval`, which then fires continuously instead of never.

Values above 0 are rounded to whole minutes and clamped to 1..1440; a log line names the adjustment. `0` still disables the periodic poll.

No new files, no new dependency: `main.js` plus one README sentence.