### PR TITLE
feat: complete the OAuth login through the admin callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Periodic HTTP polling refreshes general status values (for example battery, stat
 1. Open the adapter settings in ioBroker Admin, the instance has to be running
 2. Click **"Login with Navimow"** and login with your Navimow account
 3. The login page redirects to `http://<admin>:8081/oauth2_callbacks/navimow.0/`, admin hands the authorization code to the adapter, and the adapter restarts with the new token
+4. The callback page confirms the login and can be closed. **Login status** in the settings shows the result, it needs a reload of the settings page
+
+If admin runs with authentication, admin asks for its own login before it processes the callback. That is admin's route, not the adapter's.
 
 If the button does not work - for example because the browser cannot reach the admin address the adapter was given - the manual way still exists:
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,16 @@ Periodic HTTP polling refreshes general status values (for example battery, stat
 
 ## Setup
 
-1. Open the adapter settings in ioBroker Admin
-2. Click **"Navimow Login öffnen"** to open the Navimow login page
-3. Login with your Navimow account
-4. After login the browser shows **"Seite nicht erreichbar"** - this is expected
-5. Copy the complete URL from the browser address bar (contains `?code=XXXXX`)
-6. Paste the URL into the **Authorization Code** field and save
-7. The adapter exchanges the code for a token and starts automatically
+1. Open the adapter settings in ioBroker Admin, the instance has to be running
+2. Click **"Login with Navimow"** and login with your Navimow account
+3. The login page redirects to `http://<admin>:8081/oauth2_callbacks/navimow.0/`, admin hands the authorization code to the adapter, and the adapter restarts with the new token
+
+If the button does not work - for example because the browser cannot reach the admin address the adapter was given - the manual way still exists:
+
+1. Open the login page linked in the settings, login with your Navimow account
+2. The browser lands on an unreachable page, that is expected
+3. Copy the complete URL from the address bar (contains `?code=XXXXX`)
+4. Paste it into the **Authorization Code** field and save
 
 The token is refreshed automatically. A re-login is only needed if the refresh token expires.
 

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -36,6 +36,26 @@
       "newLine": true,
       "xs": 12, "sm": 4, "md": 4, "lg": 4, "xl": 4
     },
+    "_login_status": {
+      "type": "state",
+      "oid": "info.connection",
+      "control": "text",
+      "readOnly": true,
+      "trueText": {
+        "en": "logged in",
+        "de": "angemeldet"
+      },
+      "falseText": {
+        "en": "not logged in",
+        "de": "nicht angemeldet"
+      },
+      "label": {
+        "en": "Login status",
+        "de": "Login-Status"
+      },
+      "newLine": true,
+      "xs": 12, "sm": 4, "md": 4, "lg": 4, "xl": 4
+    },
     "authCode": {
       "type": "text",
       "newLine": true,

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -14,22 +14,27 @@
     "_oauth_info": {
       "type": "staticText",
       "text": {
-        "en": "1. Click the login link below and login with your Navimow account<br>2. After login you will be redirected - copy the complete URL from the browser address bar<br><i>The URL contains <b>?code=XXXXX</b></i><br>3. Paste the URL below and save",
-        "de": "1. Klicke auf den Login-Link unten und melde dich mit deinem Navimow-Konto an<br>2. Nach dem Login wirst du weitergeleitet - kopiere die komplette URL aus der Browser-Adressleiste<br><i>Die URL enthält <b>?code=XXXXX</b></i><br>3. Füge die URL unten ein und speichere"
+        "en": "Click <b>Login with Navimow</b> and login with your Navimow account. The authorization comes back to this instance automatically, the instance has to be running.<br>Only if that fails: open <a href=\"https://navimow-h5-fra.willand.com/smartHome/login?channel=homeassistant&client_id=homeassistant&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A1%2Fcallback\" target=\"_blank\" rel=\"noopener\">the login page manually</a>, login, and paste the complete URL of the unreachable page you land on (it contains <b>?code=XXXXX</b>) into the field below.",
+        "de": "Auf <b>Mit Navimow anmelden</b> klicken und mit dem Navimow-Konto anmelden. Die Autorisierung kommt automatisch bei dieser Instanz an, die Instanz muss dazu laufen.<br>Nur falls das nicht klappt: <a href=\"https://navimow-h5-fra.willand.com/smartHome/login?channel=homeassistant&client_id=homeassistant&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A1%2Fcallback\" target=\"_blank\" rel=\"noopener\">die Login-Seite manuell öffnen</a>, anmelden und die komplette URL der nicht erreichbaren Seite, auf der man landet (sie enthält <b>?code=XXXXX</b>), unten einfügen."
       },
       "newLine": true,
       "xs": 12, "sm": 12, "md": 12, "lg": 12, "xl": 12
     },
-    "_oauth_link": {
-      "type": "staticLink",
-      "href": "https://navimow-h5-fra.willand.com/smartHome/login?channel=homeassistant&client_id=homeassistant&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A1%2Fcallback",
+    "_oauth_button": {
+      "type": "sendTo",
+      "command": "getOAuthStartLink",
+      "jsonData": "{\"_origin\": \"${data._origin}\"}",
+      "openUrl": true,
+      "showProcess": true,
+      "timeout": 10000,
+      "variant": "contained",
+      "icon": "auth",
       "label": {
-        "en": "Open Navimow Login",
-        "de": "Navimow Login öffnen"
+        "en": "Login with Navimow",
+        "de": "Mit Navimow anmelden"
       },
       "newLine": true,
-      "xs": 12, "sm": 4, "md": 4, "lg": 4, "xl": 4,
-      "button": true
+      "xs": 12, "sm": 4, "md": 4, "lg": 4, "xl": 4
     },
     "authCode": {
       "type": "text",

--- a/io-package.json
+++ b/io-package.json
@@ -90,6 +90,7 @@
     "mode": "daemon",
     "type": "garden",
     "compact": true,
+    "messagebox": true,
     "connectionType": "cloud",
     "dataSource": "poll",
     "adminUI": {

--- a/main.js
+++ b/main.js
@@ -1245,6 +1245,8 @@ class Navimow extends utils.Adapter {
         return;
       }
       this.oauthRedirectUri = origin + '/oauth2_callbacks/' + this.namespace + '/';
+      // Only one login at a time: starting a second one (e.g. from another admin tab)
+      // overwrites this state, so the first login's callback is rejected and has to be retried.
       this.oauthState = crypto.randomBytes(16).toString('hex');
       respond({
         openUrl:

--- a/main.js
+++ b/main.js
@@ -12,8 +12,12 @@ const states = require('./lib/states.json');
 
 const API_BASE_URL = 'https://navimow-fra.ninebot.com';
 const OAUTH2_TOKEN_URL = API_BASE_URL + '/openapi/oauth/getAccessToken';
+const OAUTH2_LOGIN_URL = 'https://navimow-h5-fra.willand.com/smartHome/login';
 const CLIENT_ID = 'homeassistant';
 const CLIENT_SECRET = '57056e15-722e-42be-bbaa-b0cbfb208a52';
+// Fallback for the manual login: the browser lands on an unreachable page and the
+// user copies the code out of the address bar. The login button uses the admin
+// callback instead, see onMessage().
 const REDIRECT_URI = 'http://localhost:1/callback';
 
 
@@ -46,7 +50,10 @@ class Navimow extends utils.Adapter {
     });
     this.on('ready', this.onReady.bind(this));
     this.on('stateChange', this.onStateChange.bind(this));
+    this.on('message', this.onMessage.bind(this));
     this.on('unload', this.onUnload.bind(this));
+    this.oauthState = null;
+    this.oauthRedirectUri = '';
     this.deviceArray = [];
     this.json2iob = new Json2iob(this);
     this.requestClient = axios.create({
@@ -768,7 +775,12 @@ class Navimow extends utils.Adapter {
     };
   }
 
-  exchangeCodeForToken(code) {
+  /**
+   * @param {string} code authorization code
+   * @param {string} [redirectUri] redirect_uri the code was issued for, it has to match the login request
+   * @returns {Promise<Record<string, any> | null>} token data or null
+   */
+  exchangeCodeForToken(code, redirectUri) {
     this.log.debug('Exchanging auth code for token (code length: ' + code.length + ')');
     return this.requestClient({
       method: 'post',
@@ -779,7 +791,7 @@ class Navimow extends utils.Adapter {
         code: code,
         client_id: CLIENT_ID,
         client_secret: CLIENT_SECRET,
-        redirect_uri: REDIRECT_URI,
+        redirect_uri: redirectUri || REDIRECT_URI,
       },
     })
       .then((res) => {
@@ -1204,6 +1216,76 @@ class Navimow extends utils.Adapter {
       this.sendMowerCommand(deviceId, command);
     } else {
       this.log.warn('Unknown remote command: ' + command);
+    }
+  }
+
+  // ---- Login ----
+
+  /**
+   * The login runs through the admin message box: the login button asks for the start
+   * link, and admin routes the redirect of <admin>/oauth2_callbacks/<namespace>/ back
+   * here, so the user no longer has to copy the code out of a dead browser page.
+   *
+   * @param {ioBroker.Message} obj message from admin
+   */
+  async onMessage(obj) {
+    if (!obj || typeof obj !== 'object' || !obj.command) {
+      return;
+    }
+    const message = /** @type {Record<string, any>} */ (obj.message) || {};
+    /** @param {Record<string, any>} response */
+    const respond = (response) => obj.callback && this.sendTo(obj.from, obj.command, response, obj.callback);
+
+    if (obj.command === 'getOAuthStartLink') {
+      let origin;
+      try {
+        origin = new URL(String(message._origin)).origin;
+      } catch {
+        respond({ error: 'Admin did not report its own address, please use the manual login' });
+        return;
+      }
+      this.oauthRedirectUri = origin + '/oauth2_callbacks/' + this.namespace + '/';
+      this.oauthState = crypto.randomBytes(16).toString('hex');
+      respond({
+        openUrl:
+          OAUTH2_LOGIN_URL +
+          '?channel=' +
+          CLIENT_ID +
+          '&client_id=' +
+          CLIENT_ID +
+          '&response_type=code' +
+          '&state=' +
+          this.oauthState +
+          '&redirect_uri=' +
+          encodeURIComponent(this.oauthRedirectUri),
+      });
+      return;
+    }
+
+    if (obj.command === 'oauth2Callback') {
+      // The callback is reachable for anyone who can reach admin, so only accept the
+      // state this instance handed out for the login it started itself.
+      if (!this.oauthState || message.state !== this.oauthState) {
+        this.log.debug(
+          'OAuth callback rejected (state received: ' + (message.state ? 'yes' : 'no') + ', login pending: ' + (this.oauthState ? 'yes' : 'no') + ')',
+        );
+        respond({ error: 'This login does not belong to a login started here, please try again' });
+        return;
+      }
+      this.oauthState = null;
+      if (!message.code) {
+        respond({ error: 'No authorization code received: ' + (message.error_description || message.error || 'unknown reason') });
+        return;
+      }
+      const tokenData = await this.exchangeCodeForToken(String(message.code), this.oauthRedirectUri);
+      if (!tokenData) {
+        respond({ error: 'Token exchange failed, see the adapter log' });
+        return;
+      }
+      await this.storeToken(tokenData);
+      respond({ result: 'Login successful, the adapter restarts now. You can close this window.' });
+      // The instance is up but idle without a token, so pick up the normal startup path.
+      this.setTimeout(() => this.restart(), 1000);
     }
   }
 


### PR DESCRIPTION
Today the settings link the Navimow login with `redirect_uri=http://localhost:1/callback`. Port 1 never answers, so after the login the browser shows an error page, and the user has to copy the whole URL out of the address bar into the **Authorization Code** field.

Admin has a route for exactly this case, documented in its `DEVELOPER.md`: a redirect to `/oauth2_callbacks/<adapter>.<instance>/` is turned into an `oauth2Callback` message to the instance.

**What the PR does**

- `common.messagebox: true`, plus an `onMessage` handler with the two commands admin uses:
  - `getOAuthStartLink` builds the login URL, with `redirect_uri` derived from the admin address the caller reports (`message._origin`), and answers `{openUrl}`.
  - `oauth2Callback` exchanges the code, stores the token and restarts the instance.
- `exchangeCodeForToken(code, redirectUri)` takes the redirect URI as a parameter, since the exchange has to repeat the one used for the login. Without an argument it keeps using the old constant.
- The settings page gets a **Login with Navimow** button (`type: sendTo`) and a read-only **Login status** field bound to `info.connection`, because the login is completed in a second browser tab and the settings page otherwise shows no result at all.
- A random `state` is generated per login and a callback that does not carry it back is rejected. The route is reachable for anyone who can reach admin, so the instance only accepts a login it started itself.

**What stays**

The manual path is untouched: the login page is still linked in the settings text, and the **Authorization Code** field still accepts the pasted URL. Setups where the browser cannot reach the admin address the adapter was handed keep working.

**Verified on a live instance**

The Segway authorization server does not pin `redirect_uri` for `client_id=homeassistant` - the redirect to the admin route and the following token exchange both work, and the adapter comes up with the new token.

Two warts, both on the admin side, both outside this adapter:

- If admin runs with authentication, it asks for its own login before it processes the callback. Cause is the session cookie being `SameSite=Strict` in `@iobroker/webserver`, so the browser does not send it on the cross-site redirect. Reported as ioBroker/ioBroker.admin#3582.
- Admin gives the instance `query.timeout || 5_000` ms to answer the callback message. A very slow token exchange would show admin timeout page although the login still completes.

No new dependency. `main.js`, `admin/jsonConfig.json`, `io-package.json`, README.