### PR TITLE
chore: let the admin UI validate the polling interval range

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -48,6 +48,8 @@
       "type": "number",
       "newLine": true,
       "min": 0,
+      "max": 1440,
+      "step": 1,
       "xs": 12, "sm": 2, "md": 2, "lg": 2, "xl": 2,
       "label": {
         "en": "HTTP polling interval (in minutes)",


### PR DESCRIPTION
Follow-up to #42, in the form you suggested there.

You were right that the clamping code guarded values the UI cannot normally produce. The honest fix is to let the field validate itself: `admin/jsonConfig.json` carried only `"min": 0`, so the browser fell back to `step=1` implicitly and the upper end stayed unbounded.

This adds `"max": 1440` and an explicit `"step": 1` — nothing else, no main.js change. `0` still disables polling.
