### PR TITLE
chore: fix the repochecker findings that live in the adapter code (issue #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ ioBroker adapter for Segway Navimow robotic mowers. Uses the official [Navimow S
 
 Periodic HTTP polling refreshes general status values (for example battery, status and vehicleState) to keep them up to date. Location data and mowing progress (`location.mowingPercentage`) are provided by MQTT. During active mowing, the adapter watches the MQTT location stream and performs a controlled MQTT reconnect if location updates stop arriving while HTTP still reports an active mower state.
 
+## Sentry
+
+This adapter uses Sentry libraries to automatically report exceptions and code errors to the developers. For more details and for information how to disable the error reporting see [Sentry-Plugin Documentation](https://github.com/ioBroker/plugin-sentry#plugin-sentry)! Sentry reporting is used starting with js-controller 3.0.
+
 ## Setup
 
 1. Open the adapter settings in ioBroker Admin

--- a/main.js
+++ b/main.js
@@ -3,9 +3,9 @@
 const utils = require('@iobroker/adapter-core');
 const axios = require('axios');
 const Json2iob = require('json2iob');
-const crypto = require('crypto');
+const crypto = require('node:crypto');
 const mqtt = require('mqtt');
-const { URL } = require('url');
+const { URL } = require('node:url');
 const { createCanvas } = require('@napi-rs/canvas');
 const descriptions = require('./lib/descriptions.json');
 const states = require('./lib/states.json');
@@ -180,7 +180,7 @@ class Navimow extends utils.Adapter {
           this.log.info(
             'Periodic HTTP status polling active every ' + this.config.interval + ' minute(s). MQTT remains active for real-time updates.',
           );
-          this.updateInterval = setInterval(() => this.pollDevices('interval'), pollMs);
+          this.updateInterval = this.setInterval(() => this.pollDevices('interval'), pollMs);
         } else {
           this.log.info(
             'Periodic HTTP status polling disabled (interval=0). Relying on MQTT, with an HTTP fallback poll after ' +
@@ -1248,7 +1248,7 @@ class Navimow extends utils.Adapter {
       this.log.debug('Adapter unloading, cleaning up...');
       this.setState('info.connection', false, true);
       this.disconnectMqtt();
-      this.updateInterval && clearInterval(this.updateInterval);
+      this.updateInterval && this.clearInterval(this.updateInterval);
       this.statusStaleInterval && this.clearInterval(this.statusStaleInterval);
       this.refreshTokenTimeout && this.clearTimeout(this.refreshTokenTimeout);
       this.refreshTimeout && this.clearTimeout(this.refreshTimeout);


### PR DESCRIPTION
From the 2026-08-05 run of ioBroker.repochecker 5.19.12 in #11, only the findings that are in the adapter's own code.

- **E5004** — the periodic HTTP poll was the one timer still created with a plain `setInterval`, so the adapter framework could not clean it up by itself. Now `this.setInterval`, with the matching `this.clearInterval` on unload. Every other timer already used the adapter methods.
- **E5043** ×2 — `crypto` and `url` are built-in modules, required as `node:crypto` and `node:url` now.
- **W6023** — `io-package.json` configures the Sentry plugin, but the README said nothing about it. Added the standard notice with the link to the plugin documentation, so users can see that exceptions are reported and how to switch that off.

+8/-4 in `main.js` and `README.md`, no dependency or lock file changes.

Deliberately not in here:

- **E0028** (`engines.node` to `>=22`) drops Node 20 support, that is your call. It would also clear W0086 and W0090, which only fire because `tsconfig.json` already extends `@tsconfig/node22` while `engines` still says 20. Note the test matrix in `test-and-release.yml` runs 20.x, so that would have to go with it.
- **E2001**, **E2008**, **W4001** need npm or repository access.
- **E3012** is the deploy job that is commented out in the workflow on purpose.
- **E3014** (`needs: check-and-lint`) and **S0080** (remove the stale `.eslintrc.json`, `eslint.config.mjs` is the one in use) are one line each and I left them out to keep this to a single subject. Say the word and I'll add them.

The five **E5611** i18n errors are a separate matter — they do not need the eleven locale files from #34, the missing languages can go inline into `admin/jsonConfig.json`. Happy to do that in its own PR if you want it.
