### PR TITLE
fix: publish the mower state from the MQTT state channel instead of the lagging HTTP cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ For each mower device the following channels are created:
 
 The `status.vehicleState` state contains the current mower state.
 
+It is fed from the MQTT `state` channel as soon as that reports a change. The channel calls the field `state` and the HTTP API calls it `vehicleState`, but both use the same values, and the HTTP one answers from a server-side cache that can be one to two minutes behind — it has been seen reporting `isDocked` for a mower that was out mowing. Where the state channel has spoken within the last three minutes, its value stands and a poll landing in between does not overwrite it. While the mower is docked the channel falls quiet and the poll takes over again.
+
 **To check if the mower is currently mowing, check for `isRunning`:**
 
 ```javascript
@@ -113,6 +115,8 @@ The `location` channel receives real-time position data and mowing progress (`mo
 | `location.postureTheta`| Rotation angle (rad)   |
 | `location.vehicleState`| Vehicle state code     |
 | `location.time`        | Timestamp              |
+
+`location.vehicleState` is a number, and its meaning is not documented — neither the Navimow SDK nor the openHAB binding knows a mapping. The adapter therefore does not translate it and passes it on as it arrives. Use `status.vehicleState` for the documented state.
 
 The position data can be visualized as a mowing map using Grafana (e.g. with the Plotly or Geomap panel) or ioBroker.vis.
 

--- a/main.js
+++ b/main.js
@@ -28,6 +28,12 @@ const LOCATION_RECOVERY_COOLDOWN_MS = 5 * 60 * 1000;
 const STATUS_STALE_MS = 15 * 60 * 1000;
 const STATUS_STALE_CHECK_MS = 60 * 1000;
 const ACTIVE_LOCATION_STATES = new Set(['isRunning', 'mowing', 'isMowing', 'isMapping', 'mapping']);
+
+// How long the MQTT state channel keeps the mower state to itself after it last spoke.
+// Comfortably more than the minute or two getVehicleStatus runs behind, so a poll landing
+// in between cannot put an older state back on display.
+const STATE_CHANNEL_TRUST_MS = 3 * 60 * 1000;
+
 // States that end a mowing session. Leaving one of them for an active state starts a new
 // session and the map is cleared. Only states the mower has actually arrived in count:
 // isDocking/returning and a short isIdle can still go back to isRunning within the same
@@ -81,6 +87,7 @@ class Navimow extends utils.Adapter {
     this.locationMqttStale = {};
     this.locationHistory = {};
     this.mapResetDone = {};
+    this.lastStateChannelAt = {};
     this.lastVehicleState = {};
     this.lastMapRender = 0;
     this.mapRenderTimeout = null;
@@ -444,6 +451,17 @@ class Navimow extends utils.Adapter {
       if (channel === 'state') {
         this.lastStatusUpdate = Date.now();
         this.setState(deviceId + '.status.json', JSON.stringify(data), true);
+        // The state channel calls the mower state "state" and reports it the moment it
+        // changes, while getVehicleStatus calls it "vehicleState" and lags behind by a
+        // minute or two - it still answered "isDocked" for a mower that had been out
+        // mowing for a while. Both are the same vocabulary, so the timely one is put where
+        // the documented datapoint is, and everything reading vehicleState follows along.
+        // Only a message that actually carries a state may keep the poll out of the field
+        // afterwards - the channel also sends payloads without one.
+        if (typeof data.state === 'string' && data.state) {
+          this.lastStateChannelAt[deviceId] = this.lastStatusUpdate;
+          this.setState(deviceId + '.status.vehicleState', data.state, true);
+        }
       }
 
       // location channel: collect points and render map
@@ -1038,6 +1056,24 @@ class Navimow extends utils.Adapter {
               if (Number.isFinite(n)) v = n;
             }
             if (v != null) deviceData.battery = v;
+          }
+
+          // getVehicleStatus answers from a server-side cache that runs a minute or two
+          // behind - it reported "isDocked" for a mower that had been mowing for a while.
+          // Starting the poll later does not make its answer newer, so as long as the state
+          // channel is talking at all, it owns this field and the poll keeps out of it.
+          // Once the channel falls quiet - which it does while the mower is docked - the
+          // cache has long caught up and the poll takes over again.
+          const stateChannelAge = Date.now() - (this.lastStateChannelAt[id] || 0);
+          if (deviceData.vehicleState != null && stateChannelAge < STATE_CHANNEL_TRUST_MS && this.lastVehicleState[id]) {
+            if (deviceData.vehicleState !== this.lastVehicleState[id]) {
+              this.log.debug(
+                `Keeping vehicleState "${this.lastVehicleState[id]}" for ${id}: the state channel spoke ` +
+                  `${Math.round(stateChannelAge / 1000)}s ago, the poll still says "${deviceData.vehicleState}"`,
+              );
+            }
+            // Overwritten rather than dropped, so status.json stays complete.
+            deviceData.vehicleState = this.lastVehicleState[id];
           }
 
           this.lastStatusUpdate = Date.now();


### PR DESCRIPTION
`status.vehicleState` can be one to two minutes behind the mower.

It turned up while putting the mowing map into a vis-2 view: the map showed the mower
driving while `status.vehicleState` next to it still read `isDocked`. The debug log explains
why. At 18:07:48 the scheduled poll ran on time and `getVehicleStatus` itself answered
`"vehicleState":"isDocked"` for a mower that had been out mowing for a while. In the same
second the MQTT `state` channel reported `{"state":"isRunning"}`. So the field is served
from a cache on Segway's side, and polling more often cannot make its answer newer.

The timely value was there all along — it just lands in `status.state`, because the channel
calls the field `state` while the HTTP API calls it `vehicleState`. Everything that matters
(README, the remote buttons, users' scripts) reads `status.vehicleState`.

Two changes:

- The `state` channel now also writes `status.vehicleState`. Same vocabulary on both sides,
  so no mapping is involved.
- While the state channel has published a state within the last three minutes, the poll no
  longer overwrites that field with its own answer; it writes the value already on display,
  so `status.json` stays complete. Once the channel falls quiet — which it does while the
  mower is docked — the cache has long caught up and the poll takes over again.

Only a message that actually carries a string state arms that window, so a payload without
one cannot suppress the poll for three minutes without ever having published a fresh value.

No new states, no new settings, **no extra HTTP requests**, no change to the polling interval,
no change to the watchdog. `npx eslint main.js`, `npm run check` and `npm run test:js` are clean.
