### PR TITLE
feat: draw the mowing map in a frame that stays put (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ The adapter renders a live mowing map as a PNG image (base64 data URI) in the st
 
 The track behind it is kept in `{deviceId}.mapTrack` as a JSON array of `[x, y]` pairs in mower coordinates, rounded to centimetres. It is written at most every 30 seconds while positions are coming in, and once more when the adapter stops, and it is read back on start — so after a restart the map shows the session so far instead of staying frozen on its last image until the mower moves again. It is cleared together with the map when a new mowing session starts.
 
+#### Map Frame
+
+The frame is the rectangle of the garden, in mower coordinates, that the map image covers, and it is published in `{deviceId}.mapFrame`:
+
+```json
+{ "minX": -18, "maxX": 14, "minY": -3, "maxY": 29, "width": 800, "height": 800, "scale": 25 }
+```
+
+The image covers **exactly** the frame — its left edge is `minX`, its right edge `maxX`, its top edge `maxY`, its bottom edge `minY`, with no border around it and one scale for both axes. A world position therefore lands at `(x - minX) * scale` pixels from the left and `(maxY - y) * scale` pixels from the top. The image is at most 800 px on its longer edge; the shorter edge follows the shape of the frame.
+
+The bounds are **metres in the mower's own coordinate system** — the same numbers as `{deviceId}.location.postureX` and `postureY`, not pixels of an image. The adapter widens the frame by two metres, snapped to whole metres, whenever the mower drives outside it, and never shrinks it again. It survives a restart and a new mowing session, so a position keeps its pixel from one render and one session to the next, which is what makes it possible to lay the map over a photo of the garden at all.
+
+Because the frame never shrinks, a stray position far outside the garden would widen it for good. A position more than ten metres from the one before it is therefore not taken at face value: it is held back until the next message either confirms it — the mower really is somewhere else, for instance after leaving the dock — or contradicts it, in which case it is dropped. Should a frame still come out wrong, delete the `mapFrame` **and** `mapTrack` states of the device and restart the adapter; the frame is only ever built from the track, so both have to go.
+
 #### VIS Position Script
 
 To position a mower icon on a static background image (e.g. a screenshot of your garden from the Navimow app) in ioBroker VIS, use the following JavaScript:

--- a/main.js
+++ b/main.js
@@ -46,6 +46,17 @@ const SESSION_END_STATES = new Set(['isDocked', 'docked', 'charging']);
 // How often at most the mowing track is written to its state while the mower is out.
 const MAP_TRACK_SAVE_MS = 30 * 1000;
 
+// Mowing map: the longer edge of the rendered image in pixels. The shorter edge follows from
+// the shape of the frame, because the image covers exactly the frame and nothing besides.
+const MAP_SIZE_PX = 800;
+// The frame is widened this far past the point that triggered it and snapped to whole metres,
+// so it jumps ahead of the mower and settles instead of nudging on every location message.
+const MAP_FRAME_MARGIN_M = 2;
+// A mower drives well under a metre per second and reports its position every couple of
+// seconds, so a step this large is not driving. It is either a stray position, or the mower
+// really is somewhere else - the next message decides which.
+const LOCATION_JUMP_MAX_M = 10;
+
 // Command mapping: name -> { command, params }
 const COMMAND_MAP = {
   start: { command: 'action.devices.commands.StartStop', params: { on: true } },
@@ -92,6 +103,8 @@ class Navimow extends utils.Adapter {
     this.mapResetDone = {};
     this.lastStateChannelAt = {};
     this.lastTrackSave = {};
+    this.mapFrame = {};
+    this.pendingLocation = {};
     this.lastVehicleState = {};
     this.lastMapRender = 0;
     this.mapRenderTimeout = null;
@@ -491,6 +504,27 @@ class Navimow extends utils.Adapter {
             const y = parseFloat(p.postureY);
             if (isNaN(x) || isNaN(y)) continue;
             const last = history[history.length - 1];
+            // A single position far from the last one is not believed straight away. It
+            // would draw a spike across the map, and because the frame only ever grows it
+            // would widen the picture for good - a one-off stray reading would leave the
+            // real mowing squeezed into a corner for every session to come. The next
+            // message decides: if it lands near the held-back one, the mower really is
+            // somewhere else (back out of the dock, or the adapter restarted onto an older
+            // track) and both are taken. If not, the reading is dropped and never seen again.
+            if (last && Math.hypot(x - last.x, y - last.y) > LOCATION_JUMP_MAX_M) {
+              const pending = this.pendingLocation[deviceId];
+              if (!pending || Math.hypot(x - pending.x, y - pending.y) > LOCATION_JUMP_MAX_M) {
+                this.pendingLocation[deviceId] = { x, y };
+                this.log.debug(
+                  `Holding back position x=${x} y=${y} for ${deviceId}: ` +
+                    `${Math.hypot(x - last.x, y - last.y).toFixed(1)} m from the last one`,
+                );
+                continue;
+              }
+              this.log.debug(`Position x=${x} y=${y} for ${deviceId} confirmed by a second message, taking it`);
+              history.push(pending);
+            }
+            this.pendingLocation[deviceId] = undefined;
             if (!last || last.x !== x || last.y !== y) {
               history.push({ x, y });
             }
@@ -563,43 +597,36 @@ class Navimow extends utils.Adapter {
     if (!points || points.length < 2) return;
     this.log.debug(`Rendering map for ${deviceId}: ${points.length} points`);
 
-    const size = 800;
-    const padding = 50;
+    const frame = this.growMapFrame(deviceId, points);
 
-    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
-    for (const p of points) {
-      if (p.x < minX) minX = p.x;
-      if (p.x > maxX) maxX = p.x;
-      if (p.y < minY) minY = p.y;
-      if (p.y > maxY) maxY = p.y;
-    }
+    // One scale for both axes, and the corners of the image are the corners of the frame:
+    // that is what makes a world position land on a fixed pixel, and what keeps a garden
+    // that is longer than it is wide from being squeezed into a square.
+    const scale = MAP_SIZE_PX / Math.max(frame.maxX - frame.minX, frame.maxY - frame.minY);
+    const width = Math.round((frame.maxX - frame.minX) * scale);
+    const height = Math.round((frame.maxY - frame.minY) * scale);
+    // Y-flip only: real-world Y grows up, canvas Y grows down.
+    const projectX = (x) => (x - frame.minX) * scale;
+    const projectY = (y) => (frame.maxY - y) * scale;
 
-    const rangeX = maxX - minX || 1;
-    const rangeY = maxY - minY || 1;
-    const drawArea = size - 2 * padding;
-    const scaleX = drawArea / rangeX;
-    const scaleY = drawArea / rangeY;
-
-    const canvas = createCanvas(size, size);
+    const canvas = createCanvas(width, height);
     const ctx = canvas.getContext('2d');
 
     // Grid
     ctx.strokeStyle = 'rgba(100,100,100,0.3)';
     ctx.lineWidth = 0.5;
     for (let i = 0; i <= 10; i++) {
-      const pos = padding + (drawArea / 10) * i;
       ctx.beginPath();
-      ctx.moveTo(pos, padding);
-      ctx.lineTo(pos, size - padding);
+      ctx.moveTo((width / 10) * i, 0);
+      ctx.lineTo((width / 10) * i, height);
       ctx.stroke();
       ctx.beginPath();
-      ctx.moveTo(padding, pos);
-      ctx.lineTo(size - padding, pos);
+      ctx.moveTo(0, (height / 10) * i);
+      ctx.lineTo(width, (height / 10) * i);
       ctx.stroke();
     }
 
     // Draw path with gradient from start (blue) to current (green)
-    // Y-flip only: real-world Y grows up, canvas Y grows down
     ctx.lineWidth = 1.5;
     ctx.lineJoin = 'round';
     ctx.lineCap = 'round';
@@ -609,8 +636,8 @@ class Navimow extends utils.Adapter {
       const b = Math.round(255 - 155 * t);
       ctx.strokeStyle = `rgb(0,${g},${b})`;
       ctx.beginPath();
-      ctx.moveTo(padding + (points[i - 1].x - minX) * scaleX, padding + (maxY - points[i - 1].y) * scaleY);
-      ctx.lineTo(padding + (points[i].x - minX) * scaleX, padding + (maxY - points[i].y) * scaleY);
+      ctx.moveTo(projectX(points[i - 1].x), projectY(points[i - 1].y));
+      ctx.lineTo(projectX(points[i].x), projectY(points[i].y));
       ctx.stroke();
     }
 
@@ -618,19 +645,89 @@ class Navimow extends utils.Adapter {
     const first = points[0];
     ctx.fillStyle = '#4488ff';
     ctx.beginPath();
-    ctx.arc(padding + (first.x - minX) * scaleX, padding + (maxY - first.y) * scaleY, 5, 0, Math.PI * 2);
+    ctx.arc(projectX(first.x), projectY(first.y), 5, 0, Math.PI * 2);
     ctx.fill();
 
     // Current position marker (red)
     const last = points[points.length - 1];
     ctx.fillStyle = '#ff4444';
     ctx.beginPath();
-    ctx.arc(padding + (last.x - minX) * scaleX, padding + (maxY - last.y) * scaleY, 5, 0, Math.PI * 2);
+    ctx.arc(projectX(last.x), projectY(last.y), 5, 0, Math.PI * 2);
     ctx.fill();
 
     const base64 = 'data:image/png;base64,' + canvas.toBuffer('image/png').toString('base64');
     this.setState(deviceId + '.map', base64, true);
     void this.saveMapTrack(deviceId);
+  }
+
+  /**
+   * The rectangle of the garden, in mower coordinates, that the map image covers.
+   *
+   * It used to be re-fitted to the current point cloud on every render, so every point
+   * beyond the previous extent moved every pixel already drawn and the track crept across
+   * a background image for the whole session. The frame therefore only ever grows, and it
+   * grows a margin past the point that triggered it, snapped to whole metres - so it jumps
+   * ahead of the mower and stops changing once the garden has been driven, instead of
+   * nudging on every location message.
+   *
+   * It is not reset with the track: staying put across sessions is the point.
+   *
+   * @param {string} deviceId device
+   * @param {{x:number,y:number}[]} points the track the map is drawn from
+   * @returns {{minX:number,maxX:number,minY:number,maxY:number}} frame containing them all
+   */
+  growMapFrame(deviceId, points) {
+    const current = this.mapFrame[deviceId];
+    let { minX, maxX, minY, maxY } = current || { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity };
+    for (const p of points) {
+      if (p.x < minX) minX = Math.floor(p.x - MAP_FRAME_MARGIN_M);
+      if (p.x > maxX) maxX = Math.ceil(p.x + MAP_FRAME_MARGIN_M);
+      if (p.y < minY) minY = Math.floor(p.y - MAP_FRAME_MARGIN_M);
+      if (p.y > maxY) maxY = Math.ceil(p.y + MAP_FRAME_MARGIN_M);
+    }
+    if (current && minX === current.minX && maxX === current.maxX && minY === current.minY && maxY === current.maxY) {
+      return current;
+    }
+    const frame = { minX, maxX, minY, maxY };
+    this.mapFrame[deviceId] = frame;
+    const scale = MAP_SIZE_PX / Math.max(maxX - minX, maxY - minY);
+    // Published with the pixel geometry of the render, so a world position's pixel is
+    // (x - minX) * scale from the left and (maxY - y) * scale from the top, without
+    // anyone having to repeat the projection.
+    this.setState(
+      deviceId + '.mapFrame',
+      JSON.stringify({
+        ...frame,
+        width: Math.round((maxX - minX) * scale),
+        height: Math.round((maxY - minY) * scale),
+        scale: Math.round(scale * 100) / 100,
+      }),
+      true,
+    );
+    this.log.debug(`Map frame for ${deviceId} widened to ${JSON.stringify(frame)}`);
+    return frame;
+  }
+
+  /**
+   * @param {string} deviceId device
+   */
+  async loadMapFrame(deviceId) {
+    const state = await this.getStateAsync(deviceId + '.mapFrame');
+    if (!state?.val) return;
+    let frame;
+    try {
+      frame = JSON.parse(String(state.val));
+    } catch (e) {
+      this.log.warn(`Ignoring unreadable map frame for ${deviceId}: ${e.message}`);
+      return;
+    }
+    const { minX, maxX, minY, maxY } = frame || {};
+    if (![minX, maxX, minY, maxY].every(Number.isFinite) || minX >= maxX || minY >= maxY) {
+      this.log.warn(`Ignoring unusable map frame for ${deviceId}: ${state.val}`);
+      return;
+    }
+    this.mapFrame[deviceId] = { minX, maxX, minY, maxY };
+    this.log.debug(`Restored map frame for ${deviceId}: ${JSON.stringify(this.mapFrame[deviceId])}`);
   }
 
   /**
@@ -747,6 +844,8 @@ class Navimow extends utils.Adapter {
       return;
     }
     this.log.info(`Resetting map for ${deviceId}: ${reason}`);
+    // The frame deliberately survives: it describes the garden, not the session, and a new
+    // session drawn in the same frame lands on the same pixels as the one before it.
     this.setState(deviceId + '.map', '', true);
   }
 
@@ -1022,6 +1121,13 @@ class Navimow extends utils.Adapter {
             common: { name: 'Mowing Map track (world positions JSON)', write: false, read: true, type: 'string', role: 'json' },
             native: {},
           });
+          await this.setObjectNotExistsAsync(id + '.mapFrame', {
+            type: 'state',
+            common: { name: 'Mowing Map frame (world bounds and pixel geometry JSON)', write: false, read: true, type: 'string', role: 'json' },
+            native: {},
+          });
+          // Before the track: loading it renders the map, which needs the frame.
+          await this.loadMapFrame(id);
           await this.loadMapTrack(id);
           await this.setObjectNotExistsAsync(id + '.diagnostics', {
             type: 'channel',

--- a/main.js
+++ b/main.js
@@ -105,6 +105,7 @@ class Navimow extends utils.Adapter {
     this.lastTrackSave = {};
     this.mapFrame = {};
     this.pendingLocation = {};
+    this.lastLocation = {};
     this.lastVehicleState = {};
     this.lastMapRender = 0;
     this.mapRenderTimeout = null;
@@ -502,8 +503,14 @@ class Navimow extends utils.Adapter {
           if (p && p.postureX != null && p.postureY != null) {
             const x = parseFloat(p.postureX);
             const y = parseFloat(p.postureY);
-            if (isNaN(x) || isNaN(y)) continue;
-            const last = history[history.length - 1];
+            // Infinity survives isNaN, and a frame grown to Infinity turns the canvas
+            // dimensions into NaN, which the native canvas answers with an abort of the
+            // whole process. Nothing but a finite coordinate is of any use here anyway.
+            if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+            // The frame outlives a map reset, so the first position of a new session would
+            // widen it unchecked. lastLocation keeps the last accepted position across the
+            // reset, so the guard below covers that point too.
+            let last = history[history.length - 1] || this.lastLocation[deviceId];
             // A single position far from the last one is not believed straight away. It
             // would draw a spike across the map, and because the frame only ever grows it
             // would widen the picture for good - a one-off stray reading would leave the
@@ -523,11 +530,15 @@ class Navimow extends utils.Adapter {
               }
               this.log.debug(`Position x=${x} y=${y} for ${deviceId} confirmed by a second message, taking it`);
               history.push(pending);
+              // The confirmed one is now the last point, so an identical reading is not
+              // pushed a second time below.
+              last = pending;
             }
             this.pendingLocation[deviceId] = undefined;
             if (!last || last.x !== x || last.y !== y) {
               history.push({ x, y });
             }
+            this.lastLocation[deviceId] = { x, y };
           }
         }
         if (history.length > prevLen) {
@@ -700,7 +711,9 @@ class Navimow extends utils.Adapter {
         ...frame,
         width: Math.round((maxX - minX) * scale),
         height: Math.round((maxY - minY) * scale),
-        scale: Math.round(scale * 100) / 100,
+        // Exact, not rounded: the render projects with this value, and two decimals would
+        // put a consumer several pixels off at the far edge of the frame.
+        scale,
       }),
       true,
     );


### PR DESCRIPTION
Refs #7. This is the follow-up I said I would bring back after #49 — the restart half is
merged, this is the geometry, and nothing else.

Several people in #7 want the mowing track over a picture of their garden. Today it does not
hold still: `renderMap()` re-fits the bounding box to the current point cloud on every render,
with a separate scale per axis and a 50 px border inside a fixed 800x800 canvas. Every point
beyond the current extent moves every pixel already drawn, and a new session starts from a
different fit again, so nothing can be lined up by hand either.

**What changes**

- The bounding box moves into a `{deviceId}.mapFrame` state, read back on start. It only ever
  grows, and it grows two metres past the point that triggered it, snapped to whole metres — so
  it jumps ahead of the mower and settles, instead of nudging on every location message.
- The image covers **exactly** the frame: its corners are the frame's corners, one scale for
  both axes, no border. That is what puts a world position on a fixed pixel, and what stops a
  garden that is longer than it is wide from being squeezed into a square. The 50 px padding is
  gone; the frame margin is the breathing space.
- The state publishes the pixel geometry with the bounds (`width`, `height`, `scale`), so a
  world position's pixel is `(x - minX) * scale` from the left and `(maxY - y) * scale` from the
  top, without anyone repeating the projection.
- The frame is deliberately **not** cleared with the track. It describes the garden, not the
  session.

**Your outlier objection from #49, fixed at the source**

You were right that a grow-only frame must never be handed a stray position — and unlike last
time it is not patched with a recovery path. A position more than ten metres from the one before
is held back until the next message either confirms it (the mower really is elsewhere, e.g.
after leaving the dock) or contradicts it, in which case the reading is dropped. A mower drives
well under a metre per second and reports every couple of seconds, so ten metres is not driving.
This also keeps the spike such a reading draws today out of the map — same cause, one place.

**Measured against a recorded 3096-point session from a real mower**

```
frame changes over the session:      19        (old fit: 233)
second session, same garden:          0 changes
  fixed world point stays within:     0.00 px  (old: 187 px over the second half)
one stray reading 250 m out:
  frame area unguarded:           40096 m2     (39x)
  frame area guarded:              1024 m2     (unchanged)
  real 40 m relocation:               0 positions lost
```

**What is deliberately not in it**

No writable state, no pin, no manual-alignment section in the README, no new files. The frame is
read-only. Recovering from a frame that is wrong anyway means deleting `mapFrame` **and**
`mapTrack` and restarting — both, because a frame is only ever built from the track. That is the
path that did not work on #49.

Two things worth stating plainly. Within the very first session the frame still grows while the
mower discovers the garden, so the payoff starts with the second one. And the aspect-ratio change
happens to show nothing in the numbers above: the frame that comes out of that particular
recording is 32 x 32 m — the driven extent plus the two metre margin, snapped to whole metres —
so it renders 800x800 either way. It only bites on a garden that is not square.

`npx eslint main.js`, `npm run check` and `npm run test:js` are clean.
