### PR TITLE
fix: tell a new mowing session from a resumed one by the mowing progress (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ If HTTP polling reports an active mowing state but no MQTT `location` message is
 
 The adapter renders a live mowing map as a PNG image (base64 data URI) in the state `{deviceId}.map`. The map is automatically updated during mowing and cleared when a new mowing session starts.
 
-The track behind it is kept in `{deviceId}.mapTrack` as a JSON array of `[x, y]` pairs in mower coordinates, rounded to centimetres. It is written at most every 30 seconds while positions are coming in, and once more when the adapter stops, and it is read back on start — so after a restart the map shows the session so far instead of staying frozen on its last image until the mower moves again. It is cleared together with the map when a new mowing session starts.
+A new session is recognised by the mowing progress reported with each location message: it starts over at zero for a new session, and picks up where it left off when the mower carries on after a charging break. The mower state cannot tell the two apart — a mower that docks halfway through to charge and then drives back out looks exactly like one starting a fresh session — so the map is cleared when the progress reaches zero or falls below the value last seen, and not on a state change.
+
+The track behind it is kept in `{deviceId}.mapTrack` as JSON, `{ "percentage": 42, "points": [[x, y], …] }`, with the positions in mower coordinates rounded to centimetres. It is written at most every 30 seconds while positions are coming in, and once more when the adapter stops, and it is read back on start — so after a restart the map shows the session so far instead of staying frozen on its last image until the mower moves again. The progress is stored with it because otherwise a restart could not tell a new session from a resumed one; a track written by an older version does not carry it and is therefore dropped once, on the first start after the update, so the map stays empty until the mower drives again. It is cleared together with the map when a new mowing session starts.
 
 #### Map Frame
 

--- a/main.js
+++ b/main.js
@@ -34,15 +34,6 @@ const ACTIVE_LOCATION_STATES = new Set(['isRunning', 'mowing', 'isMowing', 'isMa
 // in between cannot put an older state back on display.
 const STATE_CHANNEL_TRUST_MS = 3 * 60 * 1000;
 
-// States that end a mowing session. Leaving one of them for an active state starts a new
-// session and the map is cleared. Only states the mower has actually arrived in count:
-// isDocking/returning and a short isIdle can still go back to isRunning within the same
-// session (cancelled dock, pause, recovery), and clearing the map there would throw away the
-// track of a session that is still running. Missing a reset only merges two tracks, which is
-// the cheaper mistake. isPaused, isLifted, Error and Offline are interruptions for the same
-// reason, so resuming out of them keeps the track collected so far.
-const SESSION_END_STATES = new Set(['isDocked', 'docked', 'charging']);
-
 // How often at most the mowing track is written to its state while the mower is out.
 const MAP_TRACK_SAVE_MS = 30 * 1000;
 
@@ -100,7 +91,7 @@ class Navimow extends utils.Adapter {
     this.runningSince = {};
     this.locationMqttStale = {};
     this.locationHistory = {};
-    this.mapResetDone = {};
+    this.lastMowingPercentage = {};
     this.lastStateChannelAt = {};
     this.lastTrackSave = {};
     this.mapFrame = {};
@@ -486,12 +477,23 @@ class Navimow extends utils.Adapter {
       if (channel === 'location') {
         const points = Array.isArray(data) ? data : [data];
 
-        // Reset map when mowingPercentage=0 arrives (before collecting new points)
+        // Decide whether this is still the same mowing session, before the new points are
+        // collected. The mowing progress is the only signal that tells a new session from a
+        // continuation: it starts over at zero for a new one and picks up where it left off
+        // when the mower carries on after a charging break.
         for (const p of points) {
-          if (p && p.mowingPercentage != null && Number(p.mowingPercentage) === 0) {
-            this.resetMap(deviceId, 'mowingPercentage=0 via MQTT');
-            break;
+          if (!p || p.mowingPercentage == null) continue;
+          const percentage = Number(p.mowingPercentage);
+          if (!Number.isFinite(percentage)) continue;
+          const previous = this.lastMowingPercentage[deviceId];
+          this.log.debug(`Mowing progress for ${deviceId}: ${previous ?? 'unknown'}% -> ${percentage}%`);
+          // Set before the reset, so the track written out by it already carries the progress
+          // of the session that is starting.
+          this.lastMowingPercentage[deviceId] = percentage;
+          if (percentage === 0 || (previous != null && percentage < previous)) {
+            this.resetMap(deviceId, `mowing progress restarted (${previous ?? 'unknown'}% -> ${percentage}%)`);
           }
+          break;
         }
 
         if (!this.locationHistory[deviceId]) {
@@ -769,8 +771,12 @@ class Navimow extends utils.Adapter {
       if (Date.now() - saved.at < MAP_TRACK_SAVE_MS) return;
     }
     // Pairs rather than objects and centimetres rather than raw floats: same picture at a
-    // fraction of the size.
-    const track = points.map((p) => [Math.round(p.x * 100) / 100, Math.round(p.y * 100) / 100]);
+    // fraction of the size. The mowing progress travels with the track, because without it a
+    // restart cannot tell the first sample of a new session from a resumed one.
+    const track = {
+      percentage: this.lastMowingPercentage[deviceId] ?? null,
+      points: points.map((p) => [Math.round(p.x * 100) / 100, Math.round(p.y * 100) / 100]),
+    };
     await this.setStateAsync(deviceId + '.mapTrack', JSON.stringify(track), true);
     // Only after the write went through, so a failed one is retried on the next call
     // instead of being remembered as saved.
@@ -790,8 +796,19 @@ class Navimow extends utils.Adapter {
       this.log.warn(`Ignoring unreadable mowing track for ${deviceId}: ${e.message}`);
       return;
     }
-    if (!Array.isArray(track)) return;
-    const points = track
+    // A bare array is a track from before the mowing progress travelled with it, so there is
+    // nothing to compare the next progress sample against. Restoring it anyway would append
+    // the next session to it and only sort itself out one session later, so it is dropped
+    // once, on the first start after the update.
+    if (Array.isArray(track)) {
+      this.log.info(`Discarding the mowing track of ${deviceId}: it carries no mowing progress to continue from`);
+      return;
+    }
+    if (!track || !Array.isArray(track.points)) return;
+    if (Number.isFinite(track.percentage)) {
+      this.lastMowingPercentage[deviceId] = track.percentage;
+    }
+    const points = track.points
       .filter((p) => Array.isArray(p) && Number.isFinite(p[0]) && Number.isFinite(p[1]))
       .map((p) => ({ x: p[0], y: p[1] }));
     if (!points.length) return;
@@ -844,9 +861,6 @@ class Navimow extends utils.Adapter {
    * @param {string} reason logged so it is visible which trigger cleared the map
    */
   resetMap(deviceId, reason) {
-    // Remember it for the session that is starting, no matter whether there was anything
-    // left to clear, so the second trigger for the same session start does not fire.
-    this.mapResetDone[deviceId] = true;
     const had = this.locationHistory[deviceId]?.length;
     this.locationHistory[deviceId] = [];
     // Unconditionally, and before the guard below: an empty history says nothing about what
@@ -1437,19 +1451,6 @@ class Navimow extends utils.Adapter {
         this.lastVehicleState[deviceId] = newState;
         if (newState !== prevState) {
           this.log.debug(`vehicleState transition: "${prevState || 'unknown'}" -> "${newState}"`);
-          // Session is over, the next start has to clear the map again.
-          if (SESSION_END_STATES.has(newState)) {
-            this.mapResetDone[deviceId] = false;
-          }
-          // Start of a new mowing session: the mowingPercentage=0 reset only fires if the
-          // mower actually reports a 0 sample over MQTT, which it skips whenever the first
-          // location message already carries a progress above zero. Without this the new
-          // track is appended to the one of the previous session. Both triggers can fire for
-          // the same session start though, and the second one would delete the points the
-          // first location message already collected, so only the first one gets to run.
-          if (SESSION_END_STATES.has(prevState) && this.isLocationActiveState(newState) && !this.mapResetDone[deviceId]) {
-            this.resetMap(deviceId, `new mowing session ("${prevState}" -> "${newState}")`);
-          }
         }
       }
       return;

--- a/main.js
+++ b/main.js
@@ -475,25 +475,42 @@ class Navimow extends utils.Adapter {
 
       // location channel: collect points and render map
       if (channel === 'location') {
-        const points = Array.isArray(data) ? data : [data];
+        let points = Array.isArray(data) ? data : [data];
 
         // Decide whether this is still the same mowing session, before the new points are
         // collected. The mowing progress is the only signal that tells a new session from a
         // continuation: it starts over at zero for a new one and picks up where it left off
         // when the mower carries on after a charging break.
-        for (const p of points) {
+        //
+        // Every point of the payload is looked at, not only the first one carrying a progress:
+        // a single message can hold the end of one session and the start of the next
+        // ([80 %, 0 %]), and stopping at the first would take the oldest sample for the truth
+        // and miss the boundary. The newest restart in the batch wins, and the points ahead of
+        // it belong to the session that just ended, so they go with it.
+        let resetAt = -1;
+        let resetFrom;
+        let progress = this.lastMowingPercentage[deviceId];
+        for (let i = 0; i < points.length; i++) {
+          const p = points[i];
           if (!p || p.mowingPercentage == null) continue;
           const percentage = Number(p.mowingPercentage);
           if (!Number.isFinite(percentage)) continue;
-          const previous = this.lastMowingPercentage[deviceId];
-          this.log.debug(`Mowing progress for ${deviceId}: ${previous ?? 'unknown'}% -> ${percentage}%`);
+          this.log.debug(`Mowing progress for ${deviceId}: ${progress ?? 'unknown'}% -> ${percentage}%`);
+          if (percentage === 0 || (progress != null && percentage < progress)) {
+            resetAt = i;
+            resetFrom = progress;
+          }
+          progress = percentage;
+        }
+        if (progress != null) {
           // Set before the reset, so the track written out by it already carries the progress
           // of the session that is starting.
-          this.lastMowingPercentage[deviceId] = percentage;
-          if (percentage === 0 || (previous != null && percentage < previous)) {
-            this.resetMap(deviceId, `mowing progress restarted (${previous ?? 'unknown'}% -> ${percentage}%)`);
-          }
-          break;
+          this.lastMowingPercentage[deviceId] = progress;
+        }
+        if (resetAt >= 0) {
+          const to = Number(points[resetAt].mowingPercentage);
+          this.resetMap(deviceId, `mowing progress restarted (${resetFrom ?? 'unknown'}% -> ${to}%)`);
+          points = points.slice(resetAt);
         }
 
         if (!this.locationHistory[deviceId]) {
@@ -802,6 +819,11 @@ class Navimow extends utils.Adapter {
     // once, on the first start after the update.
     if (Array.isArray(track)) {
       this.log.info(`Discarding the mowing track of ${deviceId}: it carries no mowing progress to continue from`);
+      // Overwrite it and drop the picture drawn from it: left on disk it would be discarded
+      // again on every start, and the map would keep showing a track the adapter no longer
+      // holds until the mower drives again.
+      await this.saveMapTrack(deviceId, true);
+      this.setState(deviceId + '.map', '', true);
       return;
     }
     if (!track || !Array.isArray(track.points)) return;


### PR DESCRIPTION
A mowing session that is interrupted by a charging break loses its map today. The mower docks at low battery, charges, drives back to where it stopped and carries on — and `"isDocked" -> "isRunning"` looks exactly like the start of a new session, so the track collected so far is thrown away and the map starts over halfway through the garden.

The mower state cannot tell the two apart. `location.mowingPercentage` can: it starts over at zero for a new session and picks up where it left off when the mower resumes. So the map is now cleared when the progress reaches zero **or falls below the value last seen**, and the `vehicleState` transition no longer clears anything.

This replaces the reset logic you reviewed in detail on #44 — the charging break is the case that showed the state transition cannot carry it. The `percentage === 0` trigger alone was not enough either, which is what #23 was about: the mower skips the zero sample whenever the first location message of a session already reports progress above zero. That case is still covered here, because such a sample is below the progress the previous session ended at.

**State format.** `{deviceId}.mapTrack` becomes `{ "percentage": 42, "points": [[x, y], …] }` — the progress has to survive a restart, otherwise the first sample after one cannot be told from a resumed session. A track written by the previous version is a bare array with no progress to continue from; restoring it anyway would append the next session to it and only sort itself out one session later, so it is **dropped once**, on the first start after the update, with an info log line. The map is then empty until the mower drives again. Worth a line in the release notes.

`mapResetDone` and `SESSION_END_STATES` go with the trigger they existed for.

**Verified** by replaying the progress sequences through the decision, old logic against new: a charging break (38 → 40 → dock → 41 → 43) resets once with the old logic and not at all with the new one; a new session at 3 % after one that ended at 100 % resets with the new logic and not with the old `=== 0` check; a restart that brings the progress back from `mapTrack` resets nothing; a non-numeric `mowingPercentage` is ignored rather than counted as a drop.

**Deliberately left out:** at the start of a session the mower keeps reporting the previous session's progress for about a minute before it drops. Usually that only puts the first few points of the new track into the old one, but if the new session has already passed the previous session's final value by the time the stale window ends, no sample below it is ever seen and the two tracks stay merged for the whole session. Still a separate, smaller problem than losing the map to every charging break, and fixing it needs the state change to arm the question and the progress to answer it — its own PR, if you want it.

Refs #7, #23
