### PR TITLE
feat: make the colour, opacity and width of the mowing track configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ The progress is right but late: for about a minute after leaving the dock the mo
 
 The track behind it is kept in `{deviceId}.mapTrack` as JSON, `{ "percentage": 42, "points": [[x, y], …] }`, with the positions in mower coordinates rounded to centimetres. It is written at most every 30 seconds while positions are coming in, and once more when the adapter stops, and it is read back on start — so after a restart the map shows the session so far instead of staying frozen on its last image until the mower moves again. The progress is stored with it because otherwise a restart could not tell a new session from a resumed one; a track written by an older version does not carry it and is therefore dropped once, on the first start after the update, so the map stays empty until the mower drives again. It is cleared together with the map when a new mowing session starts.
 
+#### Track Style
+
+Three adapter settings decide how the track is drawn, so it can be toned down to suit a picture of the garden underneath it:
+
+| Setting          | Range      | Default | Description                                                                        |
+| ---------------- | ---------- | ------- | ---------------------------------------------------------------------------------- |
+| `mapLineColor`   | any colour | empty   | Empty keeps the gradient from blue at the start to green at the current position     |
+| `mapLineOpacity` | 0.05 – 1   | 1       | Below 1 a background image shows through the track                                   |
+| `mapLineWidth`   | 0.5 – 10   | 1.5     | Line width in pixels                                                                 |
+
+The start and current position markers keep their colours and stay opaque whatever the track does. The opacity applies to the track as a whole rather than to each segment, so a stretch the mower drove twice is no darker than one it drove once.
+
 #### Map Frame
 
 The frame is the rectangle of the garden, in mower coordinates, that the map image covers, and it is published in `{deviceId}.mapFrame`:

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -59,6 +59,54 @@
         "en": "Periodic HTTP status polling interval (0 = disabled, MQTT only). MQTT remains active for real-time updates.",
         "de": "Periodisches HTTP-Status-Polling-Intervall (0 = deaktiviert, nur MQTT). MQTT bleibt für Echtzeit-Updates aktiv."
       }
+    },
+    "_map_header": {
+      "type": "header",
+      "text": {
+        "en": "Mowing Map",
+        "de": "Mähkarte"
+      },
+      "size": 3,
+      "newLine": true
+    },
+    "mapLineColor": {
+      "type": "color",
+      "newLine": true,
+      "xs": 12, "sm": 4, "md": 3, "lg": 3, "xl": 3,
+      "label": {
+        "en": "Track colour",
+        "de": "Farbe der Mähspur"
+      },
+      "help": {
+        "en": "Leave empty for the gradient from blue (start) to green (current position).",
+        "de": "Leer lassen für den Verlauf von Blau (Start) nach Grün (aktuelle Position)."
+      }
+    },
+    "mapLineOpacity": {
+      "type": "number",
+      "min": 0.05,
+      "max": 1,
+      "step": 0.05,
+      "xs": 12, "sm": 4, "md": 3, "lg": 3, "xl": 3,
+      "label": {
+        "en": "Track opacity",
+        "de": "Deckkraft der Mähspur"
+      },
+      "help": {
+        "en": "1 = opaque. Lower values let a background image show through.",
+        "de": "1 = deckend. Kleinere Werte lassen ein Hintergrundbild durchscheinen."
+      }
+    },
+    "mapLineWidth": {
+      "type": "number",
+      "min": 0.5,
+      "max": 10,
+      "step": 0.5,
+      "xs": 12, "sm": 4, "md": 3, "lg": 3, "xl": 3,
+      "label": {
+        "en": "Track width (px)",
+        "de": "Linienstärke der Mähspur (px)"
+      }
     }
   }
 }

--- a/io-package.json
+++ b/io-package.json
@@ -115,7 +115,10 @@
   "protectedNative": [],
   "native": {
     "authCode": "",
-    "interval": 5
+    "interval": 5,
+    "mapLineColor": "",
+    "mapLineOpacity": 1,
+    "mapLineWidth": 1.5
   },
   "objects": [],
   "instanceObjects": [

--- a/main.js
+++ b/main.js
@@ -713,20 +713,48 @@ class Navimow extends utils.Adapter {
       ctx.stroke();
     }
 
-    // Draw path with gradient from start (blue) to current (green)
-    ctx.lineWidth = 1.5;
-    ctx.lineJoin = 'round';
-    ctx.lineCap = 'round';
-    for (let i = 1; i < points.length; i++) {
-      const t = i / (points.length - 1);
-      const g = Math.round(120 + 135 * t);
-      const b = Math.round(255 - 155 * t);
-      ctx.strokeStyle = `rgb(0,${g},${b})`;
-      ctx.beginPath();
-      ctx.moveTo(projectX(points[i - 1].x), projectY(points[i - 1].y));
-      ctx.lineTo(projectX(points[i].x), projectY(points[i].y));
-      ctx.stroke();
+    // A value the UI cannot produce - out of range, or text where a number belongs - falls
+    // back to the default on its own: NaN fails every comparison below.
+    const color = String(this.config.mapLineColor || '').trim();
+    const opacity = Number(this.config.mapLineOpacity);
+    const lineWidth = Number(this.config.mapLineWidth);
+
+    // The track is drawn on a canvas of its own, fully opaque, and laid over the map as a
+    // single image. Stroked straight onto the map at a globalAlpha below 1, every overlap
+    // blends with itself into a darker spot - the rounded ends where two segments meet, and
+    // every stretch the mower drove twice - and the line reads as mottled rather than
+    // transparent.
+    const trackCanvas = createCanvas(width, height);
+    const trackCtx = trackCanvas.getContext('2d');
+    trackCtx.lineWidth = lineWidth >= 0.5 && lineWidth <= 10 ? lineWidth : 1.5;
+    trackCtx.lineJoin = 'round';
+    trackCtx.lineCap = 'round';
+    if (color) {
+      // One path and one stroke, so there are no seams between the segments at all.
+      trackCtx.strokeStyle = color;
+      trackCtx.beginPath();
+      trackCtx.moveTo(projectX(points[0].x), projectY(points[0].y));
+      for (let i = 1; i < points.length; i++) {
+        trackCtx.lineTo(projectX(points[i].x), projectY(points[i].y));
+      }
+      trackCtx.stroke();
+    } else {
+      // The gradient from blue at the start to green at the current position is what the map
+      // has always looked like, so it stays the default. It needs a stroke per segment.
+      for (let i = 1; i < points.length; i++) {
+        const t = i / (points.length - 1);
+        trackCtx.strokeStyle = `rgb(0,${Math.round(120 + 135 * t)},${Math.round(255 - 155 * t)})`;
+        trackCtx.beginPath();
+        trackCtx.moveTo(projectX(points[i - 1].x), projectY(points[i - 1].y));
+        trackCtx.lineTo(projectX(points[i].x), projectY(points[i].y));
+        trackCtx.stroke();
+      }
     }
+    ctx.globalAlpha = opacity >= 0.05 && opacity <= 1 ? opacity : 1;
+    ctx.drawImage(trackCanvas, 0, 0);
+    // The markers stay opaque whatever the track does - they are the two positions worth
+    // finding again on a busy background.
+    ctx.globalAlpha = 1;
 
     // Start marker (blue)
     const first = points[0];


### PR DESCRIPTION
Refs #7.

Several people in #7 want the mowing track laid over a picture of their garden. That only works if the track can be toned down to suit the picture underneath it, so three adapter settings decide how it is drawn:

| Setting | Range | Default | |
| --- | --- | --- | --- |
| `mapLineColor` | any colour | empty | Empty keeps the gradient from blue at the start to green at the current position |
| `mapLineOpacity` | 0.05 – 1 | 1 | Below 1 a background image shows through |
| `mapLineWidth` | 0.5 – 10 | 1.5 | Line width in pixels |

Nothing changes until a setting is touched, and a value the UI cannot produce — out of range, or text where a number belongs — falls back to the default on its own, because NaN fails every comparison.

**The opacity needs the compositing change that comes with it, which is why both are in one commit.** The track was stroked segment by segment straight onto the map. With a `globalAlpha` below 1 every overlap then blends with itself — the rounded ends where two segments meet, and every stretch the mower drove twice — so the line reads as mottled rather than transparent. Measured on `@napi-rs/canvas` at opacity 0.5: a stretch driven twice came out at alpha **191** against **127** for one driven once. Drawn opaque onto a canvas of its own and composited once, both are **128**. Shipped without this, the setting would simply have looked broken.

With a fixed colour the track is now also one path and one stroke rather than one per segment, which removes the seams between segments as well. The gradient still needs a stroke per segment and stays the default.

The start and current position markers keep their colours and stay opaque — they are the two positions worth finding again on a busy background.

`npm run check` and `npm run lint` pass.
