### PR TITLE
feat: mower icon and charging station on the mowing map

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Three adapter settings decide how the track is drawn, so it can be toned down to
 | `mapLineColor`   | any colour | empty   | Empty keeps the gradient from blue at the start to green at the current position     |
 | `mapLineOpacity` | 0.05 – 1   | 1       | Below 1 a background image shows through the track                                   |
 | `mapLineWidth`   | 0.5 – 10   | 1.5     | Line width in pixels                                                                 |
+| `mapMarker`      | dot, mower | dot     | The current position as a red dot or as a mower seen from above, turned the way it faces |
+| `mapMarkerSize`  | 4 – 60     | 10      | Marker size in pixels; the mower needs about 16 to 24 to be recognisable as one       |
+
+The mower marker is turned by `location.postureTheta`, the heading the mower reports itself. It is right from the first position of a session and stays right while the mower stands still. Where a position carries no heading the marker follows the last stretch driven instead. The heading travels with the track in `mapTrack` as an optional third element of each position, so a restored track keeps it, and a track written without one still reads.
 
 The start and current position markers keep their colours and stay opaque whatever the track does. The opacity applies to the track as a whole rather than to each segment, so a stretch the mower drove twice is no darker than one it drove once.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For each mower device the following channels are created:
 | `{deviceId}.remote`      | Remote control buttons                                   |
 | `{deviceId}.location`    | Real-time mower position and mowing progress (via MQTT)  |
 | `{deviceId}.diagnostics` | MQTT location watchdog diagnostics                       |
+| `{deviceId}.dockPosition` | Charging station position, writable                     |
 
 ### vehicleState
 
@@ -162,6 +163,14 @@ Three adapter settings decide how the track is drawn, so it can be toned down to
 The mower marker is turned by `location.postureTheta`, the heading the mower reports itself. It is right from the first position of a session and stays right while the mower stands still. Where a position carries no heading the marker follows the last stretch driven instead. The heading travels with the track in `mapTrack` as an optional third element of each position, so a restored track keeps it, and a track written without one still reads.
 
 The start and current position markers keep their colours and stay opaque whatever the track does. The opacity applies to the track as a whole rather than to each segment, so a stretch the mower drove twice is no darker than one it drove once.
+
+#### Charging Station
+
+The map shows the charging station once it knows where it is. The API does not say — the Navimow SDK has no endpoint carrying a coordinate — but the position the mower reports as it arrives in the dock is the station's, give or take the mower's own length, so that is what is taken.
+
+It is taken once and then left alone: `vehicleState` lags the location stream by up to a minute, so while the mower drives back out it still reads as docked, and a second opinion taken then would walk the station across the garden after it.
+
+The position lives in `{deviceId}.dockPosition` as `{"x":…,"y":…}` and can be written by hand — to correct it, or to set it without waiting for a docking. Writing an empty value forgets it and has the next docking looked at again. The frame grows to include the station, so it cannot end up outside the picture.
 
 #### Track Size
 

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -107,6 +107,46 @@
         "en": "Track width (px)",
         "de": "Linienstärke der Mähspur (px)"
       }
+    },
+    "mapMarker": {
+      "type": "select",
+      "newLine": true,
+      "xs": 12, "sm": 4, "md": 3, "lg": 3, "xl": 3,
+      "label": {
+        "en": "Current position marker",
+        "de": "Marker der aktuellen Position"
+      },
+      "options": [
+        {
+          "value": "dot",
+          "label": {
+            "en": "Dot",
+            "de": "Punkt"
+          }
+        },
+        {
+          "value": "mower",
+          "label": {
+            "en": "Mower",
+            "de": "Mäher"
+          }
+        }
+      ]
+    },
+    "mapMarkerSize": {
+      "type": "number",
+      "min": 4,
+      "max": 60,
+      "step": 1,
+      "xs": 12, "sm": 4, "md": 3, "lg": 3, "xl": 3,
+      "label": {
+        "en": "Marker size (px)",
+        "de": "Größe des Markers (px)"
+      },
+      "help": {
+        "en": "The mower needs about 16 to 24 px to be recognisable as one.",
+        "de": "Der Mäher braucht etwa 16 bis 24 px, um als solcher erkennbar zu sein."
+      }
     }
   }
 }

--- a/io-package.json
+++ b/io-package.json
@@ -118,7 +118,9 @@
     "interval": 5,
     "mapLineColor": "",
     "mapLineOpacity": 1,
-    "mapLineWidth": 1.5
+    "mapLineWidth": 1.5,
+    "mapMarker": "dot",
+    "mapMarkerSize": 10
   },
   "objects": [],
   "instanceObjects": [

--- a/main.js
+++ b/main.js
@@ -797,10 +797,15 @@ class Navimow extends utils.Adapter {
     if (!points || points.length < 2) return;
     this.log.debug(`Rendering map for ${deviceId}: ${points.length} points`);
 
-    // The charging station is passed in as another point, so the frame cannot leave it
-    // outside the picture.
+    // The charging station is grown into the frame as well, so it cannot end up outside the
+    // picture. In a call of its own rather than appended to the positions: the track runs to
+    // ten thousand of them and copying that array once a second to add one fixed point to the
+    // end of it is work for nothing.
     const dock = this.dockPosition[deviceId];
-    const frame = this.growMapFrame(deviceId, dock ? [...points, dock] : points);
+    let frame = this.growMapFrame(deviceId, points);
+    if (dock) {
+      frame = this.growMapFrame(deviceId, [dock]);
+    }
 
     const configuredSize = Number(this.config.mapMarkerSize);
     const markerSize = configuredSize >= 4 && configuredSize <= 60 ? configuredSize : 10;

--- a/main.js
+++ b/main.js
@@ -69,6 +69,10 @@ const LOCATION_JUMP_MAX_M = 10;
 // budget worth keeping in a state, and losing the beginning of the session is exactly what
 // the map is there to show.
 const MAP_TRACK_MAX_POINTS = 10000;
+
+// A position older than this is not used to locate the charging station: the mower may have
+// been docked for hours, and the last thing it reported would then be where it was mowing.
+const DOCK_POSITION_MAX_AGE_MS = 2 * 60 * 1000;
 // How far a position may sit off the straight line between its neighbours before it is worth
 // keeping. The mower drives long straight lanes and reports every two seconds, so most of what
 // it sends lies on a line already drawn: at 2 cm half the positions of a recorded session went
@@ -97,8 +101,45 @@ const COMMAND_MAP = {
  * @param {unknown} postureTheta the heading as it arrived, in radians
  * @returns {{x:number,y:number,theta?:number}} the position to keep
  */
+/**
+ * A number, but only from something that was meant as one. `Number()` alone answers 0 for
+ * null, for an empty string, for false and for an empty array, so a position missing half its
+ * coordinates would silently land on an axis instead of being refused.
+ *
+ * @param {unknown} value what stood in the field
+ * @returns {number} the number, or NaN if it was not one
+ */
+function strictNumber(value) {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string' && value.trim() !== '') return Number(value);
+  return NaN;
+}
+
+/**
+ * Read a world position out of a state value, which a user may have written by hand.
+ *
+ * @param {unknown} value the value as it stands in the state
+ * @returns {{x:number,y:number}|null} the position, or null if it is not one
+ */
+function parsePosition(value) {
+  let parsed = value;
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const x = strictNumber(/** @type {any} */ (parsed).x);
+  const y = strictNumber(/** @type {any} */ (parsed).y);
+  // Infinity survives isNaN and would grow the frame past what a canvas can be sized to.
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return { x, y };
+}
+
 function trackPoint(x, y, postureTheta) {
-  const theta = Number(postureTheta);
+  const theta = strictNumber(postureTheta);
   return Number.isFinite(theta) ? { x, y, theta } : { x, y };
 }
 
@@ -179,6 +220,7 @@ class Navimow extends utils.Adapter {
     this.lastStateChannelAt = {};
     this.lastTrackSave = {};
     this.mapFrame = {};
+    this.dockPosition = {};
     this.pendingLocation = {};
     this.lastLocation = {};
     this.lastVehicleState = {};
@@ -755,7 +797,13 @@ class Navimow extends utils.Adapter {
     if (!points || points.length < 2) return;
     this.log.debug(`Rendering map for ${deviceId}: ${points.length} points`);
 
-    const frame = this.growMapFrame(deviceId, points);
+    // The charging station is passed in as another point, so the frame cannot leave it
+    // outside the picture.
+    const dock = this.dockPosition[deviceId];
+    const frame = this.growMapFrame(deviceId, dock ? [...points, dock] : points);
+
+    const configuredSize = Number(this.config.mapMarkerSize);
+    const markerSize = configuredSize >= 4 && configuredSize <= 60 ? configuredSize : 10;
 
     // One scale for both axes, and the corners of the image are the corners of the frame:
     // that is what makes a world position land on a fixed pixel, and what keeps a garden
@@ -827,6 +875,11 @@ class Navimow extends utils.Adapter {
     // finding again on a busy background.
     ctx.globalAlpha = 1;
 
+    // Charging station, where it is known
+    if (dock) {
+      this.drawDockMarker(ctx, projectX(dock.x), projectY(dock.y), markerSize);
+    }
+
     // Start marker (blue)
     const first = points[0];
     ctx.fillStyle = '#4488ff';
@@ -836,8 +889,6 @@ class Navimow extends utils.Adapter {
 
     // Current position marker
     const last = points[points.length - 1];
-    const configuredSize = Number(this.config.mapMarkerSize);
-    const markerSize = configuredSize >= 4 && configuredSize <= 60 ? configuredSize : 10;
     if (this.config.mapMarker === 'mower') {
       // postureTheta is the mower's own heading, counted from +X counterclockwise - the same
       // convention as atan2, checked against the direction actually driven over twelve samples
@@ -1050,6 +1101,113 @@ class Navimow extends utils.Adapter {
       client.end(true, finish);
       timeoutHandle = this.setTimeout(finish, 2000);
     }));
+  }
+
+  /**
+   * Remember where the charging station is. The API has no endpoint for it - the official SDK
+   * knows only authList, mqtt/userInfo, getVehicleStatus, sendCommands and responseCommands,
+   * and none of them carries a coordinate - but the position the mower reports as it arrives
+   * in the dock is the station's, give or take the mower's own length.
+   *
+   * Taken once only, and only from a fresh position. The station does not move, so a second
+   * opinion can only make it worse: vehicleState lags the location stream by up to a minute,
+   * so while the mower drives back out it still reads as docked, and taking its position then
+   * walks the station across the garden after it. Write the state by hand to correct it, or
+   * empty it to have the next docking looked at again.
+   *
+   * @param {string} deviceId device
+   */
+  recordDockPosition(deviceId) {
+    if (this.dockPosition[deviceId]) return;
+    const lastMessage = this.lastLocationMessage[deviceId];
+    if (!lastMessage || Date.now() - lastMessage > DOCK_POSITION_MAX_AGE_MS) {
+      this.log.debug(`Not locating the charging station for ${deviceId}: no recent position`);
+      return;
+    }
+    const history = this.locationHistory[deviceId];
+    const last = history?.[history.length - 1];
+    if (!last) return;
+    this.dockPosition[deviceId] = { x: last.x, y: last.y };
+    this.log.info(`Charging station located for ${deviceId} at x=${last.x} y=${last.y} (mower arrived in the dock)`);
+    this.setState(deviceId + '.dockPosition', JSON.stringify(this.dockPosition[deviceId]), true);
+    // The station has just appeared, and the mower is docked so no position will trigger a
+    // render for hours.
+    this.renderMap(deviceId);
+  }
+
+  /**
+   * @param {string} deviceId device
+   */
+  async loadDockPosition(deviceId) {
+    const state = await this.getStateAsync(deviceId + '.dockPosition');
+    if (!state?.val) return;
+    const position = parsePosition(state.val);
+    if (!position) {
+      this.log.warn(`Ignoring unusable charging station position for ${deviceId}: ${state.val}`);
+      return;
+    }
+    this.dockPosition[deviceId] = position;
+  }
+
+  /**
+   * Take a charging station position written by hand, to correct the one the mower reported or
+   * to set it without waiting for a docking. An empty value forgets it, which also re-arms the
+   * automatic one.
+   *
+   * @param {string} deviceId device
+   * @param {unknown} value the value written to the state
+   */
+  setDockPosition(deviceId, value) {
+    if (value === '' || value == null) {
+      delete this.dockPosition[deviceId];
+      this.log.info(`Charging station position cleared for ${deviceId}`);
+      this.setState(deviceId + '.dockPosition', '', true);
+      this.renderMap(deviceId);
+      return;
+    }
+    const position = parsePosition(value);
+    if (!position) {
+      this.log.warn(`Ignoring invalid charging station position for ${deviceId}, expected {"x":..,"y":..}: ${value}`);
+      return;
+    }
+    this.dockPosition[deviceId] = position;
+    this.log.info(`Charging station position set by hand for ${deviceId}: ${JSON.stringify(position)}`);
+    this.setState(deviceId + '.dockPosition', JSON.stringify(position), true);
+    this.renderMap(deviceId);
+  }
+
+  /**
+   * The charging station: a round badge with a lightning bolt. Round because the position says
+   * nothing about which way the station faces, and a shape with a front would claim an
+   * orientation nobody knows.
+   *
+   * @param {import('@napi-rs/canvas').SKRSContext2D} ctx canvas context
+   * @param {number} x pixel position
+   * @param {number} y pixel position
+   * @param {number} size diameter in pixels
+   */
+  drawDockMarker(ctx, x, y, size) {
+    const r = size / 2;
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.fillStyle = '#2b2b2b';
+    ctx.strokeStyle = '#f2f2f2';
+    ctx.lineWidth = Math.max(0.5, size * 0.08);
+    ctx.beginPath();
+    ctx.arc(0, 0, r, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = '#00a651';
+    ctx.beginPath();
+    ctx.moveTo(-r * 0.12, -r * 0.62);
+    ctx.lineTo(r * 0.42, -r * 0.06);
+    ctx.lineTo(r * 0.08, -r * 0.06);
+    ctx.lineTo(r * 0.14, r * 0.62);
+    ctx.lineTo(-r * 0.42, r * 0.04);
+    ctx.lineTo(-r * 0.06, r * 0.04);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
   }
 
   /**
@@ -1456,8 +1614,21 @@ class Navimow extends utils.Adapter {
             common: { name: 'Mowing Map frame (world bounds and pixel geometry JSON)', write: false, read: true, type: 'string', role: 'json' },
             native: {},
           });
-          // Before the track: loading it renders the map, which needs the frame.
+          await this.setObjectNotExistsAsync(id + '.dockPosition', {
+            type: 'state',
+            common: {
+              name: 'Charging station position (world position JSON, writable)',
+              write: true,
+              read: true,
+              type: 'string',
+              role: 'json',
+            },
+            native: {},
+          });
+          // Both before the track: loading it renders the map, which needs the frame, and the
+          // charging station belongs in that first picture rather than in the next one.
           await this.loadMapFrame(id);
+          await this.loadDockPosition(id);
           await this.loadMapTrack(id);
           await this.setObjectNotExistsAsync(id + '.diagnostics', {
             type: 'channel',
@@ -1774,12 +1945,20 @@ class Navimow extends utils.Adapter {
               this.log.debug(`Waiting for the mowing progress to tell whether ${deviceId} starts a new session`);
             }
           }
+          // Arrived in the dock: the position it reported getting there is the station's.
+          if (SESSION_END_STATES.has(newState)) {
+            this.recordDockPosition(deviceId);
+          }
         }
       }
       return;
     }
 
     // ack:false = user action -> handle remote commands
+    if (channel === 'dockPosition') {
+      this.setDockPosition(deviceId, state.val);
+      return;
+    }
     if (channel !== 'remote') {
       return;
     }

--- a/main.js
+++ b/main.js
@@ -90,6 +90,19 @@ const COMMAND_MAP = {
 };
 
 /**
+ * A position for the mowing track, carrying the mower's heading where it reported one.
+ *
+ * @param {number} x world position in metres
+ * @param {number} y world position in metres
+ * @param {unknown} postureTheta the heading as it arrived, in radians
+ * @returns {{x:number,y:number,theta?:number}} the position to keep
+ */
+function trackPoint(x, y, postureTheta) {
+  const theta = Number(postureTheta);
+  return Number.isFinite(theta) ? { x, y, theta } : { x, y };
+}
+
+/**
  * How far `p` sits off the straight line from `a` to `b`.
  *
  * @param {{x:number,y:number}} a one end of the line
@@ -655,7 +668,7 @@ class Navimow extends utils.Adapter {
             if (last && Math.hypot(x - last.x, y - last.y) > LOCATION_JUMP_MAX_M) {
               const pending = this.pendingLocation[deviceId];
               if (!pending || Math.hypot(x - pending.x, y - pending.y) > LOCATION_JUMP_MAX_M) {
-                this.pendingLocation[deviceId] = { x, y };
+                this.pendingLocation[deviceId] = trackPoint(x, y, p.postureTheta);
                 this.log.debug(
                   `Holding back position x=${x} y=${y} for ${deviceId}: ` +
                     `${Math.hypot(x - last.x, y - last.y).toFixed(1)} m from the last one`,
@@ -670,7 +683,7 @@ class Navimow extends utils.Adapter {
             }
             this.pendingLocation[deviceId] = undefined;
             if (!last || last.x !== x || last.y !== y) {
-              this.pushTrackPoint(deviceId, { x, y });
+              this.pushTrackPoint(deviceId, trackPoint(x, y, p.postureTheta));
             }
             this.lastLocation[deviceId] = { x, y };
           }
@@ -821,12 +834,31 @@ class Navimow extends utils.Adapter {
     ctx.arc(projectX(first.x), projectY(first.y), 5, 0, Math.PI * 2);
     ctx.fill();
 
-    // Current position marker (red)
+    // Current position marker
     const last = points[points.length - 1];
-    ctx.fillStyle = '#ff4444';
-    ctx.beginPath();
-    ctx.arc(projectX(last.x), projectY(last.y), 5, 0, Math.PI * 2);
-    ctx.fill();
+    const configuredSize = Number(this.config.mapMarkerSize);
+    const markerSize = configuredSize >= 4 && configuredSize <= 60 ? configuredSize : 10;
+    if (this.config.mapMarker === 'mower') {
+      // postureTheta is the mower's own heading, counted from +X counterclockwise - the same
+      // convention as atan2, checked against the direction actually driven over twelve samples
+      // of a straight lane, where the two agreed to a mean of 0.003 rad. It is negated because
+      // the canvas counts Y downwards. Better than the direction of travel in two ways: it is
+      // there from the first position of a session, and it still points the right way while the
+      // mower stands still. Without it the last stretch driven has to do, and with nothing to
+      // go on the mower faces right.
+      const prev = points[points.length - 2];
+      const angle = Number.isFinite(last.theta)
+        ? -last.theta
+        : prev
+          ? Math.atan2(projectY(last.y) - projectY(prev.y), projectX(last.x) - projectX(prev.x))
+          : 0;
+      this.drawMowerMarker(ctx, projectX(last.x), projectY(last.y), markerSize, angle);
+    } else {
+      ctx.fillStyle = '#ff4444';
+      ctx.beginPath();
+      ctx.arc(projectX(last.x), projectY(last.y), markerSize / 2, 0, Math.PI * 2);
+      ctx.fill();
+    }
 
     const base64 = 'data:image/png;base64,' + canvas.toBuffer('image/png').toString('base64');
     this.setState(deviceId + '.map', base64, true);
@@ -935,7 +967,12 @@ class Navimow extends utils.Adapter {
     // restart cannot tell the first sample of a new session from a resumed one.
     const track = {
       percentage: this.lastMowingPercentage[deviceId] ?? null,
-      points: points.map((p) => [Math.round(p.x * 100) / 100, Math.round(p.y * 100) / 100]),
+      points: points.map((p) => {
+        const pair = [Math.round(p.x * 100) / 100, Math.round(p.y * 100) / 100];
+        // The heading is only read off the last position, but carrying it on every one keeps
+        // them one shape, and a track written without it still reads as it always did.
+        return Number.isFinite(p.theta) ? [...pair, Math.round(p.theta * 100) / 100] : pair;
+      }),
     };
     await this.setStateAsync(deviceId + '.mapTrack', JSON.stringify(track), true);
     // Only after the write went through, so a failed one is retried on the next call
@@ -975,7 +1012,7 @@ class Navimow extends utils.Adapter {
     }
     const points = track.points
       .filter((p) => Array.isArray(p) && Number.isFinite(p[0]) && Number.isFinite(p[1]))
-      .map((p) => ({ x: p[0], y: p[1] }));
+      .map((p) => trackPoint(p[0], p[1], p[2]));
     if (!points.length) return;
     this.locationHistory[deviceId] = points;
     // The track on disk is what was just loaded, so nothing needs writing back.
@@ -1013,6 +1050,46 @@ class Navimow extends utils.Adapter {
       client.end(true, finish);
       timeoutHandle = this.setTimeout(finish, 2000);
     }));
+  }
+
+  /**
+   * A mower seen from above, pointing the way it faces: two wheels, a body and a green front.
+   * Drawn rather than loaded, so no image has to ship with the adapter or be configured before
+   * the marker works.
+   *
+   * @param {import('@napi-rs/canvas').SKRSContext2D} ctx canvas context
+   * @param {number} x pixel position
+   * @param {number} y pixel position
+   * @param {number} size length of the mower in pixels
+   * @param {number} angle heading in canvas coordinates
+   */
+  drawMowerMarker(ctx, x, y, size, angle) {
+    const length = size;
+    const width = size * 0.7;
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate(angle);
+    // Wheels first, the body overlaps them.
+    ctx.fillStyle = '#2b2b2b';
+    ctx.fillRect(-length * 0.3, -width / 2 - width * 0.12, length * 0.3, width * 0.18);
+    ctx.fillRect(-length * 0.3, width / 2 - width * 0.06, length * 0.3, width * 0.18);
+    ctx.fillStyle = '#f2f2f2';
+    ctx.strokeStyle = '#2b2b2b';
+    ctx.lineWidth = Math.max(0.5, size * 0.06);
+    ctx.beginPath();
+    ctx.roundRect(-length / 2, -width / 2, length, width, width * 0.35);
+    ctx.fill();
+    ctx.stroke();
+    // Green front, so the direction can be read at a glance.
+    ctx.fillStyle = '#00a651';
+    ctx.beginPath();
+    ctx.moveTo(length * 0.16, -width * 0.44);
+    ctx.lineTo(length * 0.42, -width * 0.2);
+    ctx.lineTo(length * 0.42, width * 0.2);
+    ctx.lineTo(length * 0.16, width * 0.44);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
   }
 
   /**


### PR DESCRIPTION
Refs #7. Two markers, one commit each.

**The current position can be a mower instead of a red dot** (`mapMarker`, `mapMarkerSize` 4–60). Drawn with canvas primitives — body, wheels, green front — so nothing ships with the adapter or has to be configured first. The dot stays the default.

It is turned by `postureTheta`, and that was measured before being relied on: over twelve samples of a straight lane, `postureTheta` and the direction actually driven agreed to a mean of **0.003 rad**, worst case 0.08 on a single sample. A sign flip would have read +0.33 against the −0.33 reported, a quarter turn −1.9. So it is counted from +X counterclockwise, the same convention as `atan2`, and the marker negates it because the canvas counts Y downwards.

That beats the direction of travel twice over: it is there from the first position of a session, and it still points the right way while the mower stands still. Where a position carries no heading the last stretch driven does, and with neither the mower faces right. The heading travels in `mapTrack` as an optional third element per position — **the format is not broken**, a track written without it is still a list of pairs and still reads.

**The charging station is drawn once the adapter knows where it is.** The API cannot say: the official SDK exposes `authList`, `mqtt/userInfo`, `getVehicleStatus`, `sendCommands` and `responseCommands`, and none of them carries a coordinate. So the position the mower reports as it *arrives* in the dock is taken as the station's.

Once, and then left alone. `vehicleState` lags the location stream by up to a minute, so while the mower drives back out it still reads as docked — taking a second opinion then walks the station across the garden after it. Only a position younger than two minutes counts, or a mower docked for hours would put the station where it last mowed.

Round badge with a lightning bolt, because the position says nothing about which way the station faces and a shape with a front would claim an orientation nobody knows. The frame grows to include it. `{deviceId}.dockPosition` is writable — correct it, or set it without waiting for a docking; an empty value forgets it and re-arms the automatic one.

A hand-written value is parsed strictly. `Number()` answers 0 for `null`, for an empty string, for `false` and for an empty array, so `{"x":null,"y":1}` would have put the station silently on the Y axis rather than being refused. Checked against twelve rejected shapes including `1e999`, which parses to `Infinity` and would size the canvas to `NaN`.

`npm run check` and `npm run lint` pass.
